### PR TITLE
Turn off debug mode in sandbox

### DIFF
--- a/hhs_oauth_server/settings/aws-dev.py
+++ b/hhs_oauth_server/settings/aws-dev.py
@@ -9,26 +9,7 @@ ADMINS = (
 )
 MANAGERS = ADMINS
 
-ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*',
-                                             socket.gethostname()])
-
-# if ALLOWED_HOSTS == ['*', socket.gethostname()]:
-#     print("WARNING: Set DJANGO_ALLOWED_HOSTS to the hostname "
-#           "for Production operation.\n"
-#           "         Currently defaulting to %s " % ALLOWED_HOSTS)
-# Warning: on macOS hostname is case sensitive
-
-# removing security enforcement in development mode
-# DEBUG = bool_env(env('DJANGO_DEBUG', True))
-# DEBUG = True
-# Set to False while using as Developer Preview
-DEBUG = False
-
-if DEBUG:
-    print("WARNING: Set DJANGO_DEBUG environment variable to False "
-          "to run in production mode \n"
-          "         and set DJANGO_ALLOWED_HOSTS to "
-          "valid host names")
+ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*', socket.gethostname()])
 
 # Add apps for Site/Installation specific implementation here:
 # The hhs_oauth_server.hhs_oauth_server_context

--- a/hhs_oauth_server/settings/aws-impl.py
+++ b/hhs_oauth_server/settings/aws-impl.py
@@ -10,22 +10,7 @@ ADMINS = (
 )
 MANAGERS = ADMINS
 
-ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*',
-                                             socket.gethostname()])
-
-# if ALLOWED_HOSTS == ['*', socket.gethostname()]:
-#     print("WARNING: Set DJANGO_ALLOWED_HOSTS to the hostname "
-#           "for Production operation.\n"
-#           "         Currently defaulting to %s " % ALLOWED_HOSTS)
-# Warning: on macOS hostname is case sensitive
-
-# removing security enforcement in development mode
-DEBUG = True
-if DEBUG:
-    print("WARNING: Set DJANGO_DEBUG environment variable to False "
-          "to run in production mode \n"
-          "         and set DJANGO_ALLOWED_HOSTS to "
-          "valid host names")
+ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*', socket.gethostname()])
 
 # Add apps for Site/Installation specific implementation here:
 # The hhs_oauth_server.hhs_oauth_server_context

--- a/hhs_oauth_server/settings/aws-prod.py
+++ b/hhs_oauth_server/settings/aws-prod.py
@@ -10,24 +10,7 @@ ADMINS = (
 )
 MANAGERS = ADMINS
 
-ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*',
-                                             socket.gethostname()])
-
-# if ALLOWED_HOSTS == ['*', socket.gethostname()]:
-#     print("WARNING: Set DJANGO_ALLOWED_HOSTS to the hostname "
-#           "for Production operation.\n"
-#           "         Currently defaulting to %s " % ALLOWED_HOSTS)
-# Warning: on macOS hostname is case sensitive
-
-# removing security enforcement in development mode
-# DEBUG = True
-DEBUG = bool_env(env('DJANGO_DEBUG', False))
-
-if DEBUG:
-    print("WARNING: Set DJANGO_DEBUG environment variable to False "
-          "to run in production mode \n"
-          "         and set DJANGO_ALLOWED_HOSTS to "
-          "valid host names")
+ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*', socket.gethostname()])
 
 # Add apps for Site/Installation specific implementation here:
 # The hhs_oauth_server.hhs_oauth_server_context

--- a/hhs_oauth_server/settings/aws-test.py
+++ b/hhs_oauth_server/settings/aws-test.py
@@ -12,16 +12,6 @@ MANAGERS = ADMINS
 
 ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*', socket.gethostname()])
 
-
-# removing security enforcement in development mode
-DEBUG = bool_env(env('DJANGO_DEBUG', True))
-
-if DEBUG:
-    print("WARNING: Set DJANGO_DEBUG environment variable to False "
-          "to run in production mode \n"
-          "         and set DJANGO_ALLOWED_HOSTS to "
-          "valid host names")
-
 # Add apps for Site/Installation specific implementation here:
 # The hhs_oauth_server.hhs_oauth_server_context
 

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -50,7 +50,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*', socket.gethostname()])
 
-DEBUG = bool_env(env('DJANGO_DEBUG', True))
+DEBUG = False
 
 # apps and middlewares
 INSTALLED_APPS = [


### PR DESCRIPTION
Debug mode is currently enabled in our sandbox environment at sandbox.bluebutton.cms.gov.

In general, debug mode should not be enabled in any public-facing environment. If our dev and test environments were only accessible via OpenVPN, we could enable this mode. As it is, this isn't an option. I removed the option to even set it otherwise outside of a local environment.