### PR TITLE
enable mobile redirect uris (CBBP-845)

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -54,11 +54,11 @@ class CustomRegisterApplicationForm(forms.ModelForm):
 
     def clean_redirect_uris(self):
         redirect_uris = self.cleaned_data.get('redirect_uris')
-        if getattr(settings, 'REQUIRE_HTTPS_REDIRECT_URIS', False):
+        if getattr(settings, 'BLOCK_HTTP_REDIRECT_URIS', True):
             if redirect_uris:
                 for u in redirect_uris.split():
-                    if not u.startswith("https://"):
-                        msg = _('Redirect URIs are required to use https.')
+                    if u.startswith("http://"):
+                        msg = _('Redirect URIs must not use http.')
                         raise forms.ValidationError(msg)
         return redirect_uris
 

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -508,7 +508,10 @@ OFFLINE = False
 EXTERNAL_LOGIN_TEMPLATE_NAME = '/v1/accounts/upstream-login'
 
 # Should be set to True in production and False in all other dev and test environments
-REQUIRE_HTTPS_REDIRECT_URIS = True
+# Replace with BLOCK_HTTP_REDIRECT_URIS per CBBP-845 to support mobile apps
+# REQUIRE_HTTPS_REDIRECT_URIS = True
+BLOCK_HTTP_REDIRECT_URIS = False
+
 #
 # MyMedicare Authentication Integration
 #

--- a/hhs_oauth_server/settings/dev.py
+++ b/hhs_oauth_server/settings/dev.py
@@ -50,4 +50,6 @@ FHIR_SERVER_CONF = {
 }
 
 # Should be set to True in production and False in all other dev and test environments
-REQUIRE_HTTPS_REDIRECT_URIS = False
+# Replace with BLOCK_HTTP_REDIRECT_URIS per CBBP-845 to support mobile apps
+# REQUIRE_HTTPS_REDIRECT_URIS = True
+BLOCK_HTTP_REDIRECT_URIS = False

--- a/hhs_oauth_server/settings/test.py
+++ b/hhs_oauth_server/settings/test.py
@@ -14,4 +14,6 @@ REQUEST_CALL_TIMEOUT = (5, 120)
 
 OFFLINE = True
 # Should be set to True in production and False in all other dev and test environments
-REQUIRE_HTTPS_REDIRECT_URIS = False
+# Replace with BLOCK_HTTP_REDIRECT_URIS per CBBP-845 to support mobile apps
+# REQUIRE_HTTPS_REDIRECT_URIS = True
+BLOCK_HTTP_REDIRECT_URIS = False


### PR DESCRIPTION
switch REQUIRE_HTTPS_REDIRECT_URIS to BLOCK_HTTP_REDIRECT_URIs
This enables mobile apps to use web hooks registered on the mobile device but prevents the use of http:// endpoints in production.

The web deployment scripts have been updated in sync with these changes.

https://issues.hhsdevcloud.us/browse/CBBP-845
