### PR TITLE
CBBP-817 - Token based throttling on protected views

### DIFF
--- a/apps/dot_ext/throttling.py
+++ b/apps/dot_ext/throttling.py
@@ -1,0 +1,62 @@
+from rest_framework.throttling import SimpleRateThrottle
+
+HEADERS = {
+    'Remaining': 'X-RateLimit-Remaining',
+    'Limit': 'X-RateLimit-Limit',
+    'Reset': 'X-RateLimit-Reset',
+}
+
+
+class TokenRateThrottle(SimpleRateThrottle):
+    """
+    Limits the rate of API calls that may be made from a given token.
+    The token will be used as a unique cache key.
+    For anonymous requests, the IP address of the request will
+    be used.
+    """
+    scope = 'token'
+
+    def get_cache_key(self, request, view):
+        try:
+            ident = request.oauth.access_token
+        except AttributeError:
+            ident = self.get_ident(request)
+
+        return self.cache_format % {
+            'scope': self.scope,
+            'ident': ident,
+        }
+
+    def allow_request(self, request, view):
+        # run this first to populate/update self.history, self.now, self.duration, self.num_requests
+        result = super(TokenRateThrottle, self).allow_request(request, view)
+        try:
+            request.META[HEADERS['Remaining']] = len(self.history) - self.num_requests
+            request.META[HEADERS['Limit']] = self.num_requests
+            if self.history:
+                remaining_duration = self.duration - (self.now - self.history[-1])
+            else:
+                remaining_duration = self.duration
+
+            request.META[HEADERS['Reset']] = remaining_duration
+        # Allows for throttling to be turned off completely
+        except AttributeError:
+            pass
+
+        return result
+
+
+class ThrottleMiddleware(object):
+    scope = 'throttle'
+
+    def process_response(self, request, response):
+        """
+        Setting the standard rate limit headers
+        :param request:
+        :param response:
+        :return:
+        """
+        response[HEADERS['Limit']] = request.META.get(HEADERS['Limit'])
+        response[HEADERS['Remaining']] = request.META.get(HEADERS['Remaining'])
+        response[HEADERS['Reset']] = request.META.get(HEADERS['Reset'])
+        return response

--- a/apps/fhir/bluebutton/decorators.py
+++ b/apps/fhir/bluebutton/decorators.py
@@ -20,6 +20,7 @@ def require_valid_token():
             if valid:
                 # Note, resource_owner is not a very good name for this
                 request.resource_owner = oauthlib_req.user
+                request.oauth = oauthlib_req
                 return view_func(request, *args, **kwargs)
 
             return build_error_response(401, 'The token authentication failed.')

--- a/apps/fhir/bluebutton/tests/test_read.py
+++ b/apps/fhir/bluebutton/tests/test_read.py
@@ -93,7 +93,10 @@ class ThrottleReadRequestTest(BaseApiTest):
                                       scope='read')
 
     # See test settings for test throttle values
-    def test_read_throttle(self):
+    @patch('apps.dot_ext.throttling.TokenRateThrottle.get_rate')
+    def test_read_throttle(self,
+                           mock_rates):
+        mock_rates.return_value = '1/day'
         # create the user
         first_access_token = self.create_token('John', 'Smith')
 

--- a/apps/fhir/bluebutton/tests/test_read.py
+++ b/apps/fhir/bluebutton/tests/test_read.py
@@ -103,11 +103,11 @@ class ThrottleReadRequestTest(BaseApiTest):
             reverse(
                 'bb_oauth_fhir_read_or_update_or_delete',
                 kwargs={
-                    'resource_type': 'Patient',
+                    'resource_type': 'Nothing',
                     'resource_id': 12}),
             Authorization="Bearer %s" % (first_access_token))
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)
 
         self.assertTrue(response.has_header("X-RateLimit-Limit"))
         self.assertEqual(response.get("X-RateLimit-Limit"), "1")
@@ -123,7 +123,7 @@ class ThrottleReadRequestTest(BaseApiTest):
             reverse(
                 'bb_oauth_fhir_read_or_update_or_delete',
                 kwargs={
-                    'resource_type': 'Patient',
+                    'resource_type': 'Nothing',
                     'resource_id': 12}),
             Authorization="Bearer %s" % (first_access_token))
 
@@ -147,7 +147,7 @@ class ThrottleReadRequestTest(BaseApiTest):
             reverse(
                 'bb_oauth_fhir_search',
                 kwargs={
-                    'resource_type': 'Patient'}),
+                    'resource_type': 'Nothing'}),
             Authorization="Bearer %s" % (first_access_token))
 
         self.assertEqual(response.status_code, 429)
@@ -160,8 +160,8 @@ class ThrottleReadRequestTest(BaseApiTest):
             reverse(
                 'bb_oauth_fhir_read_or_update_or_delete',
                 kwargs={
-                    'resource_type': 'Patient',
+                    'resource_type': 'Nothing',
                     'resource_id': 12}),
             Authorization="Bearer %s" % (second_access_token))
 
-        self.assertEqual(response.status_code, 403)
+        self.assertEqual(response.status_code, 404)

--- a/apps/fhir/bluebutton/tests/test_read.py
+++ b/apps/fhir/bluebutton/tests/test_read.py
@@ -92,7 +92,6 @@ class ThrottleReadRequestTest(BaseApiTest):
                                       application,
                                       scope='read')
 
-    # See test settings for test throttle values
     @patch('apps.dot_ext.throttling.TokenRateThrottle.get_rate')
     def test_read_throttle(self,
                            mock_rates):

--- a/apps/fhir/bluebutton/views/read.py
+++ b/apps/fhir/bluebutton/views/read.py
@@ -3,7 +3,7 @@ import logging
 
 from ..constants import ALLOWED_RESOURCE_TYPES
 from ..decorators import require_valid_token
-from ..errors import build_error_response, method_not_allowed
+from ..errors import build_error_response
 
 from apps.fhir.bluebutton.utils import (request_call,
                                         get_host_url,
@@ -31,9 +31,6 @@ def read(request, resource_type, resource_id, *args, **kwargs):
     logger.debug("resource_type: %s" % resource_type)
     logger.debug("Interaction: read")
     logger.debug("Request.path: %s" % request.path)
-
-    if request.method != 'GET':
-        return method_not_allowed(['GET'])
 
     if resource_type not in ALLOWED_RESOURCE_TYPES:
         logger.info('User requested read access to the %s resource type' % resource_type)

--- a/apps/fhir/bluebutton/views/read.py
+++ b/apps/fhir/bluebutton/views/read.py
@@ -12,11 +12,15 @@ from apps.fhir.bluebutton.utils import (request_call,
                                         get_resourcerouter,
                                         build_rewrite_list,
                                         get_response_text)
+from rest_framework.decorators import throttle_classes, api_view
+from apps.dot_ext.throttling import TokenRateThrottle
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
 
 @require_valid_token()
+@api_view(['GET'])
+@throttle_classes([TokenRateThrottle])
 def read(request, resource_type, resource_id, *args, **kwargs):
     """
     Read from Remote FHIR Server

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -4,7 +4,7 @@ import logging
 
 from ..constants import ALLOWED_RESOURCE_TYPES
 from ..decorators import require_valid_token
-from ..errors import build_error_response, method_not_allowed
+from ..errors import build_error_response
 
 from apps.fhir.bluebutton.utils import (request_get_with_parms,
                                         build_rewrite_list,
@@ -32,9 +32,6 @@ def search(request, resource_type, *args, **kwargs):
     logger.debug("resource_type: %s" % resource_type)
     logger.debug("Interaction: search. ")
     logger.debug("Request.path: %s" % request.path)
-
-    if request.method != 'GET':
-        return method_not_allowed(['GET'])
 
     if resource_type not in ALLOWED_RESOURCE_TYPES:
         logger.info('User requested search access to the %s resource type' % resource_type)

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -14,11 +14,16 @@ from apps.fhir.bluebutton.utils import (request_get_with_parms,
                                         post_process_request,
                                         get_response_text)
 
+from rest_framework.decorators import throttle_classes, api_view
+from apps.dot_ext.throttling import TokenRateThrottle
+
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
 
 @require_valid_token()
+@api_view(['GET'])
+@throttle_classes([TokenRateThrottle])
 def search(request, resource_type, *args, **kwargs):
     """
     Search from Remote FHIR Server

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -82,7 +82,7 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
-        'token': None,
+        'token': env('TOKEN_THROTTLE_RATE', None),
     },
 }
 

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -53,6 +53,8 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
+    'rest_framework',
+
     # 1st Party (in-house) ----------
     'apps.accounts',
     'apps.capabilities',
@@ -77,6 +79,12 @@ INSTALLED_APPS = [
     'oauth2_provider',
 
 ]
+
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_RATES': {
+        'token': None,
+    },
+}
 
 # Used for testing for optional apps in templates without causing a crash
 # used in SETTINGS_EXPORT below.
@@ -103,6 +111,7 @@ MIDDLEWARE_CLASSES = [
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'social_django.middleware.SocialAuthExceptionMiddleware',
+    'apps.dot_ext.throttling.ThrottleMiddleware',
 ]
 
 CORS_ORIGIN_ALLOW_ALL = bool_env(env('CORS_ORIGIN_ALLOW_ALL', True))
@@ -134,6 +143,13 @@ TEMPLATES = [
 
 
 WSGI_APPLICATION = 'hhs_oauth_server.wsgi.application'
+
+CACHES = {
+    'default': {
+        'BACKEND': os.environ.get('CACHE_BACKEND', 'django.core.cache.backends.locmem.LocMemCache'),
+        'LOCATION': os.environ.get('CACHE_LOCATION', 'unique-snowflake'),
+    },
+}
 
 # database configuration
 if os.environ.get('DATABASES_CUSTOM'):

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -82,7 +82,7 @@ INSTALLED_APPS = [
 
 REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
-        'token': env('TOKEN_THROTTLE_RATE', None),
+        'token': env('TOKEN_THROTTLE_RATE', '100000/s'),
     },
 }
 

--- a/hhs_oauth_server/settings/test.py
+++ b/hhs_oauth_server/settings/test.py
@@ -26,4 +26,10 @@ OAUTH2_PROVIDER = {
     'OAUTH2_BACKEND_CLASS': 'apps.dot_ext.oauth2_backends.OAuthLibSMARTonFHIR',
     'ALLOWED_REDIRECT_URI_SCHEMES': ['https', 'http']
 }
+
+REST_FRAMEWORK = {
+    'DEFAULT_THROTTLE_RATES': {
+        'token': '1/day',
+    },
+}
 # http required in ALLOWED_REDIRECT_URI_SCHEMES for tests to function correctly

--- a/hhs_oauth_server/settings/test.py
+++ b/hhs_oauth_server/settings/test.py
@@ -27,9 +27,4 @@ OAUTH2_PROVIDER = {
     'ALLOWED_REDIRECT_URI_SCHEMES': ['https', 'http']
 }
 
-REST_FRAMEWORK = {
-    'DEFAULT_THROTTLE_RATES': {
-        'token': '1/day',
-    },
-}
 # http required in ALLOWED_REDIRECT_URI_SCHEMES for tests to function correctly

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -5,6 +5,7 @@ django-bootstrap-form
 django-cors-headers
 django-localflavor
 django-settings-export
+djangorestframework
 
 # support
 boto

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -27,6 +27,7 @@ django-ses==0.7.1
 django-settings-export==1.1.0
 django-storages==1.5.1
 django==1.11.9
+djangorestframework==3.7.7
 docutils==0.14            # via botocore
 flake8==2.6.0
 idna==2.6                 # via requests


### PR DESCRIPTION
- On a per-token basis throttle access to `read` and `search` views.
- Uses the [throttling interface from django rest framework](http://www.django-rest-framework.org/api-guide/throttling/)
- When enabled responses will include the same rate limit [headers as github](https://developer.github.com/v3/rate_limit/)
- In production this requires a [cache](https://docs.djangoproject.com/en/2.0/topics/cache/) to be configured for Django, it will work with the in memory cache as a default but that will not sync accross an auto scaling group.