### PR TITLE
Set request to django.HttpRequest in authed views

### DIFF
--- a/apps/fhir/bluebutton/views/read.py
+++ b/apps/fhir/bluebutton/views/read.py
@@ -22,6 +22,8 @@ logger = logging.getLogger('hhs_server.%s' % __name__)
 @api_view(['GET'])
 @throttle_classes([TokenRateThrottle])
 def read(request, resource_type, resource_id, *args, **kwargs):
+    # reset request back to django.HttpRequest
+    request = request._request
     """
     Read from Remote FHIR Server
     # Example client use in curl:

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -25,6 +25,8 @@ logger = logging.getLogger('hhs_server.%s' % __name__)
 @api_view(['GET'])
 @throttle_classes([TokenRateThrottle])
 def search(request, resource_type, *args, **kwargs):
+    # reset request back to django.HttpRequest
+    request = request._request
     """
     Search from Remote FHIR Server
     """


### PR DESCRIPTION
The DRF Request object type does not behave in
the same way as Django's HttpRequest and broke
downstream code.

The `request` variable was pointed at
the django `request._request` HttpRequest
in DRF wrapped views.