### PR TITLE
Set APPEND_SLASH to false

### DIFF
--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -42,6 +42,7 @@ AUTH_PASSWORD_VALIDATORS = [
 ALLOWED_HOSTS = env('DJANGO_ALLOWED_HOSTS', ['*', socket.gethostname()])
 
 DEBUG = False
+APPEND_SLASH = False
 
 # apps and middlewares
 INSTALLED_APPS = [


### PR DESCRIPTION
This setting turns out to be extremely problematic when taking POST requests. It literally results in an endpoint guaranteed to return a 500 error. I'm not certain this is responsible for any of the issues our developers are experiencing, but it very well may be. This is of no value to an API, and of potential danger.