### PR TITLE
CBBP-881 Do not restrict applications by scope

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -8,7 +8,6 @@ from django.utils.translation import ugettext_lazy as _
 from oauth2_provider.forms import AllowForm as DotAllowForm
 from oauth2_provider.models import get_application_model
 from oauth2_provider.scopes import get_scopes_backend
-from apps.capabilities.models import ProtectedCapability
 from oauth2_provider.settings import oauth2_settings
 from .oauth2_validators import set_regex, compare_to_regex
 from oauth2_provider.validators import urlsplit
@@ -22,17 +21,6 @@ class CustomRegisterApplicationForm(forms.ModelForm):
         agree_label = u'Yes I have read and agree to the <a target="_blank" href="%s">API Terms of Service Agreement</a>*' % (
             settings.TOS_URI)
         super(CustomRegisterApplicationForm, self).__init__(*args, **kwargs)
-        choices = []
-        groups = user.groups.values_list('id', flat=True)
-        pcs = None
-        for g in groups:
-            pcs = ProtectedCapability.objects.filter(group=g)
-            for i in pcs:
-                choices.append([i.pk, i.title])
-        self.fields['scope'].choices = choices
-        self.fields['scope'].label = "Scope*"
-        if pcs:
-            self.fields['scope'].initial = pcs
         self.fields['authorization_grant_type'].choices = settings.GRANT_TYPES
         self.fields['client_type'].initial = 'confidential'
         self.fields['agree'].label = mark_safe(agree_label)
@@ -45,7 +33,8 @@ class CustomRegisterApplicationForm(forms.ModelForm):
 
     class Meta:
         model = get_application_model()
-        fields = ('name', 'scope', 'client_type',
+        fields = ('name',
+                  'client_type',
                   'authorization_grant_type', 'redirect_uris',
                   'logo_uri', 'policy_uri', 'tos_uri', 'contacts',
                   'agree')

--- a/apps/dot_ext/scopes.py
+++ b/apps/dot_ext/scopes.py
@@ -22,10 +22,7 @@ class CapabilitiesScopes(BaseScopes):
         Returns a list that contains all the capabilities related
         to the current application.
         """
-        if application:
-            return list(application.scope.values_list('slug', flat=True))
-        else:
-            return []
+        return list(ProtectedCapability.objects.values_list('slug', flat=True))
 
     def get_default_scopes(self, application=None, request=None, *args, **kwargs):
         """

--- a/apps/dot_ext/templates/oauth2_provider/application_detail.html
+++ b/apps/dot_ext/templates/oauth2_provider/application_detail.html
@@ -43,22 +43,6 @@
             </li>
 
             <li>
-                <p><b>{% trans "Scopes" %}</b></p> 
-                {% for s in application.scope.all %}
-                    <pre>{{ s.slug }}</pre>
-                {% endfor %}
-            </li>
-
-            <li>
-                <p><b>{% trans "Scope Detail By Tag" %}</b></p>
-                {% for s in application.scope.all %}
-                <p>Tag: <strong>{{ s.slug }}</strong></p>
-                <p><pre>{{ s.protected_resources }}</pre></p>
-                {% endfor %}
-            </li>
-
-
-            <li>
                 <p><b>{% trans "Redirect Uris" %}</b></p>
                 <pre>{{ application.redirect_uris }}</pre>
             </li>

--- a/apps/dot_ext/tests/test_scopes.py
+++ b/apps/dot_ext/tests/test_scopes.py
@@ -48,7 +48,7 @@ class TestScopesBackendClass(BaseApiTest):
         application.scope.add(capability_a, capability_b)
         # retrieve the list of the scopes available for the application
         available_scopes = CapabilitiesScopes().get_available_scopes(application=application)
-        assert available_scopes == ['capability-a', 'capability-b']
+        assert available_scopes == ['capability-a', 'capability-b', 'capability-c']
 
     def test_get_default_scopes(self):
         """
@@ -64,7 +64,7 @@ class TestScopesBackendClass(BaseApiTest):
         application.scope.add(capability_a, capability_b)
         # retrieve the list of the scopes available for the application
         default_scopes = CapabilitiesScopes().get_default_scopes(application=application)
-        assert default_scopes == ['capability-a', 'capability-b']
+        assert default_scopes == ['capability-a', 'capability-b', 'capability-c']
 
     def test_backend_works_with_no_capabilities(self):
         """

--- a/apps/dot_ext/tests/test_views.py
+++ b/apps/dot_ext/tests/test_views.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 
 import json
 
+from unittest import skip
+
 from django.core.urlresolvers import reverse
 
 from oauth2_provider.compat import parse_qs, urlparse
@@ -12,6 +14,7 @@ from ..models import Application
 
 
 class TestApplicationUpdateView(BaseApiTest):
+    @skip("Skipping until restricted scopes are reenabled. They were disabled for https://issues.hhsdevcloud.us/browse/CBBP-881")
     def test_update_form_show_allowed_scopes(self):
         """
         """


### PR DESCRIPTION
In order to acheave this all applications appear to have all scopes.
The alternative is to rip out the scope behavior completely, which seems to be engrained in the oauth2_provider library. Thoughts?

