### PR TITLE
Set 404 header to non-italic style

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -11,7 +11,6 @@ strong {
 .Extra404Large {
 	font-family: "Times New Roman", Times, serif;
 	font-size: 64px;
-	font-style: italic;
 	font-weight: bolder;
 	color: #39F;
 }

--- a/templates/500.html
+++ b/templates/500.html
@@ -12,7 +12,6 @@ strong {
 .Extra404Large {
 	font-family: "Times New Roman", Times, serif;
 	font-size: 64px;
-	font-style: italic;
 	font-weight: bolder;
 	color: #39F;
 }


### PR DESCRIPTION
See, for example, sandbox.bluebutton.cms.gov/im-not-a-url:

Old
![screen shot 2018-02-12 at 10 25 44 pm](https://user-images.githubusercontent.com/25462603/36132186-bd3938ac-1043-11e8-9938-1a465fa304ac.png)

New
![screen shot 2018-02-12 at 10 25 54 pm](https://user-images.githubusercontent.com/25462603/36132197-c6b45380-1043-11e8-9749-a5cf144509d8.png)
