### PR TITLE
CBBP-882 Allow auto redirect to account.mymedicare.gov

### DIFF
--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -153,7 +153,7 @@ def mymedicare_login(request):
     if request.user.is_authenticated():
         return HttpResponseRedirect(next_uri)
     AnonUserState.objects.create(state=state, next_uri=next_uri)
-    if 'apps.testclient' in settings.INSTALLED_APPS:
+    if getattr(settings, 'ALLOW_CHOOSE_LOGIN', False):
         return HttpResponseRedirect(reverse('mymedicare-choose-login'))
     return HttpResponseRedirect(mymedicare_login_url)
 

--- a/hhs_oauth_server/settings/dev.py
+++ b/hhs_oauth_server/settings/dev.py
@@ -8,6 +8,8 @@ HOSTNAME_URL = env('HOSTNAME_URL', 'http://127.0.0.1:8000')
 INVITE_REQUEST_ADMIN = env(
     'DJANGO_INVITE_REQUEST_ADMIN', 'change-me@example.com')
 
+ALLOW_CHOOSE_LOGIN = True
+
 DEV_SPECIFIC_APPS = [
     # Installation/Site Specific apps based on  -----------------
     # 'storages',


### PR DESCRIPTION
By default the user will now be forwarded to account.mymedicare.gov,
locally developers can still choose local login if they wish.