### PR TITLE
Add basic python Oauth2 client with load test

### DIFF
--- a/load_test/.gitignore
+++ b/load_test/.gitignore
@@ -1,0 +1,2 @@
+Pipfile.lock
+*.pyc

--- a/load_test/Pipfile
+++ b/load_test/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+
+[dev-packages]
+
+
+
+[packages]
+
+requests-oauthlib = "*"
+flask = "*"
+locust = "*"

--- a/load_test/README.md
+++ b/load_test/README.md
@@ -1,0 +1,45 @@
+# Locust.io Load Testing
+
+This is a first pass at load testing, with many rough edges and things not done
+yet.
+
+## Quick Start
+
+Install dependencies:
+
+```
+pipenv install
+pipenv shell
+```
+
+Run Oauth 2.0 flow and get access code:
+
+```
+export LOCUST_BB_LOAD_TEST_CLIENT_ID=<client_id>
+export LOCUST_BB_LOAD_TEST_CLIENT_SECRET=<client_secret>
+python oauth_flask_client.py
+# Navigate to localhost:5000 and follow the oauth flow
+# Copy the auth token from the logs, should be last debug line
+```
+
+The client ID and secret should be from when you registered your oauth
+application.
+
+Finally, run the load test using that access code:
+
+```
+export LOCUST_BB_LOAD_TEST_ACCESS_TOKEN="<auth_token>"
+locust --host https://sandbox.bluebutton.cms.gov
+# Navigate to localhost:8089 and run some locusts
+```
+
+## Files
+
+- `oauth_flask_client.py`: The flask application that can run the Oauth 2.0 flow
+  and get the access token.  It should use it to request the "userinfo"
+  resource.  See https://bluebutton.cms.gov/developers/#core-resources.
+- `locustfile.py`: The file run by locust.io, with the default name.  This
+  doesn't yet have Oauth 2.0 support, instead it depends on you to explicitly
+  set the access token.
+- `Pipfile`: Dependencies, as specified by pipenv:
+  https://github.com/pypa/pipenv

--- a/load_test/locustfile.py
+++ b/load_test/locustfile.py
@@ -1,0 +1,111 @@
+#!/usr/bin/python
+"""
+BlueButton (2.0!) Locust Test
+
+A basic locust test for blue button.  This right now simply has stubs for the
+oauth flow and tries to retrieve the access token from the
+"LOCUST_BB_LOAD_TEST_ACCESS_TOKEN" environment variable.
+
+Things to do:
+
+- Somehow integrate oauth setup
+- Actually load test oauth setup (comments below)
+- Load test various resource endpoints rather than just profile, with test
+  users/data
+"""
+
+from locust import HttpLocust, TaskSet, task, web
+from requests_oauthlib import OAuth2Session
+import os
+
+# The global oauth2 metadata
+#
+# TODO: Make this work with multiple clients...  Each client may already get a
+# different context, but if not a throwaway version could be just to number the
+# clients and store the access tokens in a dict.
+#
+# It's important that the access token is correct on this side, so we can see if
+# the load test reveals cases where an access token is returned but not
+# authorized.
+access_token = None
+oauth2_state = None
+
+# XXX: Setting this now explicitly because I haven't figured out how to
+# integrate the oauth handshake fully into locust.
+if "LOCUST_BB_LOAD_TEST_ACCESS_TOKEN" in os.environ:
+    access_token = os.environ["LOCUST_BB_LOAD_TEST_ACCESS_TOKEN"]
+
+# Get the client ID and secret for the oauth application from the environment
+client_id = os.environ["LOCUST_BB_LOAD_TEST_CLIENT_ID"]
+client_secret = os.environ["LOCUST_BB_LOAD_TEST_CLIENT_SECRET"]
+
+# Authorization and token URLs.  Not important now because this load test does
+# not load test oauth.
+authorization_base_url = 'https://github.com/login/oauth/authorize'
+token_url = 'https://github.com/login/oauth/access_token'
+
+
+# Resource being accessed.  This is currently the only thing the load test is
+# testing.
+resource_url = 'https://sandbox.bluebutton.cms.gov/v1/connect/userinfo'
+
+
+# We need to specify this in the oauth handshake with bluebutton because of a
+# bug where this is required:
+# https://github.com/CMSgov/bluebutton-web-server/issues/507#issuecomment-365418905
+redirect_uri = "http://localhost:5000/callback"
+
+
+@web.app.route('/callback')
+def callback():
+    """
+    Oauth 2.0: Step 2
+
+    This is the callback used in the Oauth2 flow.  For now, we're just
+    registering it with the locust flask server, which might be an issue when
+    we're dealing with multiple clients.
+
+    See https://docs.locust.io/en/latest/extending-locust.html#adding-web-routes
+    for how to use this.
+    """
+    global access_token
+    pass
+
+
+class UserBehavior(TaskSet):
+    def on_start(self):
+        """
+        Oauth 2.0: Step 1
+
+        Handle initialization behavior.  Right now this doesn't actually load
+        test the oauth part, just sets it up so that the actual load test tasks
+        can run.
+
+        It should be possible to test this by creating a "custom client" as
+        described in
+        https://docs.locust.io/en/latest/testing-other-systems.html, and
+        treating "request failure" as a failure of the oauth handshake.
+        """
+        github = OAuth2Session(client_id, redirect_uri=redirect_uri)
+        authorization_url, state = github.authorization_url(authorization_base_url)
+        response = self.client.get(authorization_url)
+        # This is the login page, because you need to log in to grant access...
+        # The next page would be the authorization page, which would then
+        # redirect you back to the callback.
+        print response.content
+
+    @task
+    def get_resource(self):
+        """
+        Retrieve a resource using the global access token, currently set
+        manually.
+        """
+        self.client.headers['Authorization'] = 'Bearer ' + access_token
+        response = self.client.get(resource_url)
+        print response.content
+
+
+class WebsiteUser(HttpLocust):
+    task_set = UserBehavior
+    min_wait = 5000
+    max_wait = 9000

--- a/load_test/locustfile.py
+++ b/load_test/locustfile.py
@@ -92,7 +92,7 @@ class UserBehavior(TaskSet):
         # This is the login page, because you need to log in to grant access...
         # The next page would be the authorization page, which would then
         # redirect you back to the callback.
-        print response.content
+        print(response.content)
 
     @task
     def get_resource(self):
@@ -102,7 +102,7 @@ class UserBehavior(TaskSet):
         """
         self.client.headers['Authorization'] = 'Bearer ' + access_token
         response = self.client.get(resource_url)
-        print response.content
+        print(response.content)
 
 
 class WebsiteUser(HttpLocust):

--- a/load_test/oauth_flask_client.py
+++ b/load_test/oauth_flask_client.py
@@ -1,0 +1,123 @@
+#!/bin/python
+"""
+Oauth Flask Client
+
+Taken from
+http://requests-oauthlib.readthedocs.io/en/latest/examples/real_world_example.html#real-example
+almost directly, with a few small changes (like turning on insecure transport
+for local testing, adding more logging, and configuring the variables and paths
+to point to blue button).
+
+This spins up a flask server listening on port 5000.  Navigating to
+localhost:5000 will then walk you through the oauth flow.
+
+This is not integrated with locust in any way, but maybe locust could be used by
+pointing it to this server?  Haven't figured that out.
+
+The locust test can take the access token as input, so to load test the non
+oauth parts of the application, one flow could be to run this to get the token,
+then plug that into the locust test.
+"""
+
+from requests_oauthlib import OAuth2Session
+from flask import Flask, request, redirect, session, url_for
+from flask.json import jsonify
+import os
+
+app = Flask(__name__)
+
+# https://stackoverflow.com/questions/27785375/testing-flask-oauthlib-locally-without-https
+os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = '1'
+
+
+###################################################
+# Application Specific Settings
+#
+# This doesn't have any fancy setup/config files.  All the parameters specific
+# to your application should go here.
+# - client_id: ID of the application you registered with the resource provider
+# - client_secret: The corresponding client secret
+# - authorization_base_url: The URL to send the first step of the oauth flow
+# - token_url: The URL to send the third step of the oauth flow to
+# - redirect_uri: The URL to send the client to in step two of the oauth flow
+# - resource_url: The URL of the resource to access after oauth  is complete
+#
+# client_id = os.environ["LOCUST_BB_LOAD_TEST_CLIENT_ID"]
+# client_secret = os.environ["LOCUST_BB_LOAD_TEST_CLIENT_SECRET"]
+# authorization_base_url = 'http://localhost:8000/v1/o/authorize/'
+# token_url = 'http://localhost:8000/v1/o/token/'
+# redirect_uri = "http://localhost:5000/callback"
+
+client_id = os.environ["LOCUST_BB_LOAD_TEST_CLIENT_ID"]
+client_secret = os.environ["LOCUST_BB_LOAD_TEST_CLIENT_SECRET"]
+authorization_base_url = 'https://sandbox.bluebutton.cms.gov/v1/o/authorize/'
+token_url = 'https://sandbox.bluebutton.cms.gov/v1/o/token/'
+redirect_uri = "http://localhost:5000/callback"
+resource_url = 'https://sandbox.bluebutton.cms.gov/v1/connect/userinfo'
+###################################################
+
+
+@app.route("/")
+def demo():
+    """Step 1: User Authorization.
+
+    Redirect the user/resource owner to the OAuth provider (i.e. Github)
+    using an URL with a few key OAuth parameters.
+    """
+    app.logger.debug("Step 1: User Authorization.")
+    github = OAuth2Session(client_id, redirect_uri=redirect_uri)
+    authorization_url, state = github.authorization_url(authorization_base_url)
+    app.logger.debug("Authorization URL: %s", authorization_url)
+
+    # State is used to prevent CSRF, keep this for later.
+    session['oauth_state'] = state
+    app.logger.debug("OAuth State: %s", session['oauth_state'])
+    return redirect(authorization_url)
+
+
+# Step 2: User authorization, this happens on the provider.
+
+@app.route("/callback", methods=["GET"])
+def callback():
+    """ Step 3: Retrieving an access token.
+
+    The user has been redirected back from the provider to your registered
+    callback URL. With this redirection comes an authorization code included
+    in the redirect URL. We will use that to obtain an access token.
+    """
+    app.logger.debug("Step 1: Retrieving Access Token.")
+    github = OAuth2Session(client_id, state=session['oauth_state'], redirect_uri=redirect_uri)
+    app.logger.debug("Authorization Response: %s", request.url)
+    app.logger.debug("Token URL: %s", token_url)
+    token = github.fetch_token(token_url, client_secret=client_secret,
+                               authorization_response=request.url)
+
+    # At this point you can fetch protected resources but lets save
+    # the token and show how this is done from a persisted token
+    # in /resource.
+    session['oauth_token'] = token
+    app.logger.debug("Token: %s", session['oauth_token'])
+
+    return redirect(url_for('.resource'))
+
+
+@app.route("/resource", methods=["GET"])
+def resource():
+    """Fetching a protected resource using an OAuth 2 token.
+    """
+    app.logger.debug("Fetching URL: %s with token %s", resource_url, session['oauth_token'])
+    github = OAuth2Session(client_id, token=session['oauth_token'], redirect_uri=redirect_uri)
+    res = github.get(resource_url)
+    app.logger.debug("Resource response code: %s", res.status_code)
+
+    app.logger.debug("### Access Token: %s ###", session['oauth_token']['access_token'])
+
+    return jsonify(res.json())
+
+
+if __name__ == "__main__":
+    # This allows us to use a plain HTTP callback
+    os.environ['DEBUG'] = "1"
+
+    app.secret_key = os.urandom(24)
+    app.run(debug=True)


### PR DESCRIPTION
The load test isn't fully integrated, but this shows an example oauth
2.0 application and an example load test that uses the auth token
retrieved from the oauth 2.0 handshake.  See README for how to run the
test (currently running against the developer sandbox).

Things missing:

- Load testing the oauth 2.0 handshake
- Load testing anything meaningful besides the userinfo endpoint