### PR TITLE
Remove prod homepage

### DIFF
--- a/hhs_oauth_server/urls.py
+++ b/hhs_oauth_server/urls.py
@@ -36,6 +36,7 @@ if IsAppInstalled("apps.mymedicare_cb"):
         url(r'^mymedicare/', include('apps.mymedicare_cb.urls')),
     ]
 
-urlpatterns += [
-    url(r'^$', home, name='home'),
-]
+if not getattr(settings, 'NO_UI', False):
+    urlpatterns += [
+        url(r'^$', home, name='home'),
+    ]


### PR DESCRIPTION
Allows us to change a setting for prod to return a 404 error when the user visits api.sandbox.bluebutton.cms.gov

We will likely move many more URLs under this flag later, but I wanted to keep it simple given the timing.