### PR TITLE
CBBP-950 Accept and handle the application/fhir+json type

### DIFF
--- a/apps/fhir/bluebutton/views/read.py
+++ b/apps/fhir/bluebutton/views/read.py
@@ -1,4 +1,4 @@
-from django.http import JsonResponse
+from rest_framework.response import Response
 import logging
 
 from ..constants import ALLOWED_RESOURCE_TYPES
@@ -12,7 +12,13 @@ from apps.fhir.bluebutton.utils import (request_call,
                                         get_resourcerouter,
                                         build_rewrite_list,
                                         get_response_text)
-from rest_framework.decorators import throttle_classes, api_view
+from apps.fhir.parsers import FHIRParser
+from apps.fhir.renderers import FHIRRenderer
+
+from rest_framework.decorators import throttle_classes, api_view, parser_classes, renderer_classes
+from rest_framework.parsers import JSONParser
+from rest_framework.renderers import JSONRenderer
+
 from apps.dot_ext.throttling import TokenRateThrottle
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
@@ -20,6 +26,8 @@ logger = logging.getLogger('hhs_server.%s' % __name__)
 
 @require_valid_token()
 @api_view(['GET'])
+@parser_classes([JSONParser, FHIRParser])
+@renderer_classes([JSONRenderer, FHIRRenderer])
 @throttle_classes([TokenRateThrottle])
 def read(request, resource_type, resource_id, *args, **kwargs):
     # reset request back to django.HttpRequest
@@ -103,7 +111,7 @@ def read(request, resource_type, resource_id, *args, **kwargs):
     text_in = get_response_text(fhir_response=response)
     text_out = post_process_request(request, host_path, text_in, rewrite_url_list)
 
-    return JsonResponse(text_out)
+    return Response(text_out)
 
 
 def standard_404():

--- a/apps/fhir/parsers.py
+++ b/apps/fhir/parsers.py
@@ -1,0 +1,5 @@
+from rest_framework.parsers import JSONParser
+
+
+class FHIRParser(JSONParser):
+    media_type = 'application/fhir+json'

--- a/apps/fhir/renderers.py
+++ b/apps/fhir/renderers.py
@@ -1,0 +1,5 @@
+from rest_framework.renderers import JSONRenderer
+
+
+class FHIRRenderer(JSONRenderer):
+    media_type = 'application/fhir+json'

--- a/apps/testclient/tests.py
+++ b/apps/testclient/tests.py
@@ -63,6 +63,25 @@ class BlueButtonClientApiFhirTest(TestCase):
         uri = "%s%s" % (
             self.testclient_setup['patient_uri'], self.patient)
         response = self.client.get(uri)
+        self.assertEqual(response['Content-Type'], "application/json")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.patient)
+
+    def test_get_patient_fhir(self):
+        """
+        Test get patient
+        """
+        uri = "%s%s" % (
+            self.testclient_setup['patient_uri'], self.patient)
+        response = self.client.get(uri, HTTP_ACCEPT='application/fhir+json')
+        self.assertEqual(response['Content-Type'], "application/fhir+json")
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, self.patient)
+
+        # Test for search endpoint
+        uri = self.testclient_setup['patient_uri']
+        response = self.client.get(uri, HTTP_ACCEPT='application/fhir+json')
+        self.assertEqual(response['Content-Type'], "application/fhir+json")
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, self.patient)
 
@@ -86,6 +105,7 @@ class BlueButtonClientApiFhirTest(TestCase):
         response = self.client.get(uri)
         response_data = response.json()
         self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], "application/json")
         self.assertEqual(len(response_data['entry']), 12)
         self.assertContains(response, "ExplanationOfBenefit")
 


### PR DESCRIPTION
Treat this media type the same as application/json.
Gives us a place to do any custom rendering/parsing that might be needed in future.