### PR TITLE
CBBP-957 If New Relic ini file is present, configure the NR agent

### DIFF
--- a/hhs_oauth_server/wsgi.py
+++ b/hhs_oauth_server/wsgi.py
@@ -1,4 +1,5 @@
 import os
+import newrelic.agent
 # from getenv import env
 from django.core.wsgi import get_wsgi_application
 
@@ -23,6 +24,11 @@ if os.path.isfile(EXEC_FILE):
 
 else:
     print("no custom variables set:[%s] - Not Found" % EXEC_FILE)
+
+# If the New Relic config file is present, load and configure the agent
+if os.path.isfile(os.path.join(DJANGO_CUSTOM_SETTINGS_DIR, 'newrelic.ini')):
+    newrelic.agent.initialize(os.path.join(DJANGO_CUSTOM_SETTINGS_DIR, 'newrelic.ini'))
+
 # If custom-envvars or web server didn't pre-set DJANGO_SETTINGS_MODULE
 # then we set it to the default
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "hhs_oauth_server.settings.base")

--- a/requirements/requirements.in
+++ b/requirements/requirements.in
@@ -15,8 +15,7 @@ pytz
 configparser
 dj-database-url
 pyjwt
-
-
+newrelic
 
 # test coverage
 coverage

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -28,6 +28,7 @@ flake8==2.6.0
 idna==2.6                 # via requests
 jsonschema==2.5.1
 mccabe==0.5.0             # via flake8
+newrelic==2.106.0.87
 oauthlib==1.0.3
 pluggy==0.3.1             # via tox
 py==1.4.31                # via tox


### PR DESCRIPTION
Looks for a `newrelic.ini` file alongside (in the same location as `custom-envvars.py`), loading the config if it is found. Meant to accompany https://github.com/CMSgov/bluebutton-web-deployment/pull/1254. 