### PR TITLE
CBBP-975 Enable normal oauth access denied redirect flow

### DIFF
--- a/templates/design_system/authorize.html
+++ b/templates/design_system/authorize.html
@@ -58,7 +58,7 @@
       
                      <div class="ds-l-row">
                       <div class="ds-l-col--auto">
-                          <a class="ds-c-button  ds-c-button--outline ds-u-margin-top--1 ds-u-display--block ds-u-md-display--inline-block" href ="{% url 'do_not_approve' %}" >No, do not approve access</a>
+			      <input type="submit" class="ds-c-button ds-c-button--outline ds-u-margin-top--1 ds-u-display--block ds-u-md-display--inline-block" value="No, do not approve access" \>
                       </div>     
                      </center> 
             </form>


### PR DESCRIPTION
If the authorize form does not submit an `allow` field oauth2_provider
handles the rest.