### PR TITLE
CBBP-1017 Add get_user_id_salt to handle decoding hex str value for user id salt

### DIFF
--- a/apps/accounts/end_user_signup_forms.py
+++ b/apps/accounts/end_user_signup_forms.py
@@ -13,7 +13,7 @@ from django.utils.dates import MONTHS
 from django.utils.translation import ugettext_lazy as _
 from django.utils.crypto import pbkdf2
 
-from .models import UserProfile, create_activation_key, UserRegisterCode
+from .models import UserProfile, create_activation_key, UserRegisterCode, get_user_id_salt
 from ..fhir.bluebutton.models import Crosswalk
 
 from .models import MFA_CHOICES
@@ -167,7 +167,7 @@ class SimpleUserSignupForm(forms.Form):
         # TODO: Add Crosswalk Create.
         Crosswalk.objects.create(user=new_user,
                                  user_id_hash=binascii.hexlify(pbkdf2(self.cleaned_data['id_number'],
-                                                                      settings.USER_ID_SALT,
+                                                                      get_user_id_salt(settings.USER_ID_SALT),
                                                                       settings.USER_ID_ITERATIONS)).decode("ascii"))
         #
         group = Group.objects.get(name='BlueButton')

--- a/apps/accounts/end_user_signup_forms.py
+++ b/apps/accounts/end_user_signup_forms.py
@@ -167,7 +167,7 @@ class SimpleUserSignupForm(forms.Form):
         # TODO: Add Crosswalk Create.
         Crosswalk.objects.create(user=new_user,
                                  user_id_hash=binascii.hexlify(pbkdf2(self.cleaned_data['id_number'],
-                                                                      get_user_id_salt(settings.USER_ID_SALT),
+                                                                      get_user_id_salt(),
                                                                       settings.USER_ID_ITERATIONS)).decode("ascii"))
         #
         group = Group.objects.get(name='BlueButton')

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -353,7 +353,7 @@ class UserRegisterCode(models.Model):
     def save(self, commit=True, **kwargs):
         if commit:
             self.user_id_hash = binascii.hexlify(pbkdf2(self.user_id_hash,
-                                                        get_user_id_salt(settings.USER_ID_SALT),
+                                                        get_user_id_salt(),
                                                         settings.USER_ID_ITERATIONS)).decode("ascii")
             if self.sender:
                 up = UserProfile.objects.get(user=self.sender)

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -353,7 +353,7 @@ class UserRegisterCode(models.Model):
     def save(self, commit=True, **kwargs):
         if commit:
             self.user_id_hash = binascii.hexlify(pbkdf2(self.user_id_hash,
-                                                        settings.USER_ID_SALT,
+                                                        get_user_id_salt(settings.USER_ID_SALT),
                                                         settings.USER_ID_ITERATIONS)).decode("ascii")
             if self.sender:
                 up = UserProfile.objects.get(user=self.sender)
@@ -546,3 +546,14 @@ def export_admin_log(sender, instance, **kwargs):
                 'action_time': instance.action_time}
 
         admin_logger.info(msg)
+
+
+def get_user_id_salt(salt=settings.USER_ID_SALT):
+    """
+    Assumes `USER_ID_SALT` is a hex encoded value. Decodes the salt val,
+    returning binary data represented by the hexadecimal string.
+
+    :param: salt
+    :return: bytes
+    """
+    return binascii.unhexlify(salt)

--- a/apps/fhir/bluebutton/models.py
+++ b/apps/fhir/bluebutton/models.py
@@ -41,7 +41,7 @@ class Crosswalk(models.Model):
     def save(self, commit=True, **kwargs):
         if commit:
             self.user_id_hash = binascii.hexlify(pbkdf2(self.user_id_hash,
-                                                        get_user_id_salt(settings.USER_ID_SALT),
+                                                        get_user_id_salt(),
                                                         settings.USER_ID_ITERATIONS)).decode("ascii")
             super(Crosswalk, self).save(**kwargs)
 

--- a/apps/fhir/bluebutton/models.py
+++ b/apps/fhir/bluebutton/models.py
@@ -2,6 +2,7 @@ import logging
 from requests import Response
 from django.conf import settings
 from django.db import models
+from apps.accounts.models import get_user_id_salt
 from apps.fhir.server.models import ResourceRouter
 from django.utils.crypto import pbkdf2
 import binascii
@@ -40,7 +41,7 @@ class Crosswalk(models.Model):
     def save(self, commit=True, **kwargs):
         if commit:
             self.user_id_hash = binascii.hexlify(pbkdf2(self.user_id_hash,
-                                                        settings.USER_ID_SALT,
+                                                        get_user_id_salt(settings.USER_ID_SALT),
                                                         settings.USER_ID_ITERATIONS)).decode("ascii")
             super(Crosswalk, self).save(**kwargs)
 

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -468,7 +468,7 @@ AUTHENTICATION_BACKENDS = ('apps.accounts.email_auth_backend.EmailBackend',
                            'django.contrib.auth.backends.ModelBackend')
 
 # Change these for production
-USER_ID_SALT = env('DJANGO_USER_ID_SALT', "nottherealpepper")
+USER_ID_SALT = env('DJANGO_USER_ID_SALT', "6E6F747468657265616C706570706572")
 USER_ID_ITERATIONS = int(env("DJANGO_USER_ID_ITERATIONS", "2"))
 
 USER_ID_TYPE_CHOICES = (('H', 'HICN'),


### PR DESCRIPTION
Builds on and is meant to take the place of work in https://github.com/CMSgov/bluebutton-web-server/pull/566.

Instead of providing a `bool` setting for switching between string and hex string depending on env, always treat the `USER_ID_SALT` as a hex-encoded value.