### PR TITLE
Remove link to home in 404 template

### DIFF
--- a/templates/404.html
+++ b/templates/404.html
@@ -29,7 +29,6 @@ strong {
 <p class="Normal404Text">We couldn't find the page you requested.
 
 </p>
-<h3><a href="{% url 'home' %}" >Back to Home Page</a></h3>
 
 </body>
 </html>


### PR DESCRIPTION
The reverse call to home in the template caued a cascade of errors when NO_UI was enabled.

NO_UI removes "home" from the route table