### PR TITLE
Add client ID to admin

### DIFF
--- a/apps/dot_ext/admin.py
+++ b/apps/dot_ext/admin.py
@@ -22,7 +22,7 @@ class MyApplication(Application):
 
 class MyApplicationAdmin(admin.ModelAdmin):
 
-    list_display = ("name", "user", "authorization_grant_type", "scopes",
+    list_display = ("name", "user", "authorization_grant_type", "client_id",
                     "skip_authorization", "created", "updated")
     list_filter = ("name", "user", "client_type", "authorization_grant_type",
                    "skip_authorization")

--- a/apps/dot_ext/admin.py
+++ b/apps/dot_ext/admin.py
@@ -23,7 +23,7 @@ class MyApplication(Application):
 class MyApplicationAdmin(admin.ModelAdmin):
 
     list_display = ("name", "user", "authorization_grant_type", "client_id",
-                    "skip_authorization", "created", "updated")
+                    "skip_authorization", "scopes", "created", "updated")
     list_filter = ("name", "user", "client_type", "authorization_grant_type",
                    "skip_authorization")
     radio_fields = {

--- a/apps/fhir/bluebutton/admin.py
+++ b/apps/fhir/bluebutton/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from apps.fhir.bluebutton.models import (Crosswalk)
+from apps.fhir.bluebutton.models import Crosswalk
 
 
 class CrosswalkAdmin(admin.ModelAdmin):


### PR DESCRIPTION
The lack of the client_id column was making it very difficult to find the apps our developers wanted added to production. This makes it easier!