### PR TITLE
[CBBP-986] Generate release notes based on commit message

### DIFF
--- a/ops/build_release.sh
+++ b/ops/build_release.sh
@@ -73,7 +73,27 @@ else
   NEWTAG="r$NEWRELEASENUM"
 fi
 
+RELEASE_NOTES="RELEASE.txt"
+[ ! -f $RELEASE_NOTES ] && echo "Must run script in top-level project directory." >&2 && exit 1
+TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
+
+commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)
+
+echo "$NEWTAG - $(date +%Y-%m-%d)" > $TMPFILE
+echo "================" >> $TMPFILE
+echo "" >> $TMPFILE
+echo "$commits" >> $TMPFILE
+echo "" >> $TMPFILE
+
+cat $RELEASE_NOTES >> $TMPFILE
+
 git checkout -b "release-$NEWRELEASENUM"
+
+mv $TMPFILE $RELEASE_NOTES
+
+git add $RELEASE_NOTES
+
+git commit -m"Update release notes for $NEWTAG"
 
 git tag -a -m"$PROJECT_NAME release $NEWTAG" -s "$NEWTAG"
 


### PR DESCRIPTION
Adding a step to `build_release.sh` to generate release notes based on the commits since the last release.

As an example, if we compare what's currently on `release-notes` branch to the previous release (`r11`), it produces notes that look like:

```
release-notes - 2018-05-01
================

- add release notes generation/update step to build_release.sh
- Test for explicit URL structure (#592)
- Raise exception for failure response from backend (#591)
- Merge pull request #590 from CMSgov/develop
```

Since we've change our merge strategy to "squash and merge," if we tag `r12` after merging this PR, the notes should look like:

```
r12 - 2018-05-01
================

- [CBBP-986] Generate release notes based on commit message
- Test for explicit URL structure (#592)
- Raise exception for failure response from backend (#591)
- Merge pull request #590 from CMSgov/develop
```

Going forward, we should try our best to include the relevant JIRA ticket ID in the titles of PRs so that release notes can be easily mapped back to a record of the work.