### PR TITLE
Recheck fhir_id on any request if it is empty

### DIFF
--- a/apps/fhir/bluebutton/views/generic.py
+++ b/apps/fhir/bluebutton/views/generic.py
@@ -87,6 +87,10 @@ class FhirDataView(APIView):
                 # Recheck perms
                 self.crosswalk = self.check_resource_permission(request, resource_type, *args, **kwargs)
             else:
+                if backend_data.get('total', 0) > 1:
+                    # Don't return a 404 because retrying later will not fix this.
+                    raise UpstreamServerException("Duplicate beneficiaries found")
+
                 raise exceptions.NotFound("The requested Beneficiary has no entry, however this may change")
 
         self.resource_type = resource_type

--- a/apps/test.py
+++ b/apps/test.py
@@ -108,3 +108,22 @@ class BaseApiTest(TestCase):
                                       passwd,
                                       application,
                                       scope='read')
+
+    def create_token_no_fhir(self, first_name, last_name):
+        passwd = '123456'
+        user = self._create_user(first_name,
+                                 passwd,
+                                 first_name=first_name,
+                                 last_name=last_name,
+                                 email="%s@%s.net" % (first_name, last_name))
+        Crosswalk.objects.get_or_create(user=user,
+                                        fhir_source=get_resourcerouter())
+
+        # create a oauth2 application and add capabilities
+        application = self._create_application("%s_%s_test" % (first_name, last_name), user=user)
+        application.scope.add(self.read_capability, self.write_capability)
+        # get the first access token for the user 'john'
+        return self._get_access_token(first_name,
+                                      passwd,
+                                      application,
+                                      scope='read')


### PR DESCRIPTION
Allows tokens created for Beneficiaries that did not have a match in the system to be used and updated once a match does exist in the system.