### PR TITLE
Return application/json on 4xx/5xx errors

### DIFF
--- a/hhs_oauth_server/urls.py
+++ b/hhs_oauth_server/urls.py
@@ -1,4 +1,6 @@
 from django.conf import settings
+from django.http import JsonResponse
+from rest_framework import status
 from django.conf.urls import include, url
 from django.contrib import admin
 from apps.accounts.views.oauth2_profile import openidconnect_userinfo
@@ -9,6 +11,7 @@ from hhs_oauth_server.hhs_oauth_server_context import IsAppInstalled
 admin.autodiscover()
 
 ADMIN_REDIRECTOR = getattr(settings, 'ADMIN_PREPEND_URL', '')
+
 
 urlpatterns = [
     url(r'.well-known/', include('apps.wellknown.urls')),
@@ -36,3 +39,27 @@ if not getattr(settings, 'NO_UI', False):
     urlpatterns += [
         url(r'^$', home, name='home'),
     ]
+
+handler500 = 'hhs_oauth_server.urls.server_error'
+handler400 = 'hhs_oauth_server.urls.bad_request'
+
+
+# TODO Replace this with defaults from rest_framework once upgrated to > 3.7.7
+def server_error(request, *args, **kwargs):
+    """
+    Generic 500 error handler.
+    """
+    data = {
+        'error': 'Server Error (500)'
+    }
+    return JsonResponse(data, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+
+def bad_request(request, exception, *args, **kwargs):
+    """
+    Generic 400 error handler.
+    """
+    data = {
+        'error': 'Bad Request (400)'
+    }
+    return JsonResponse(data, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
http errors don't make sense for API responses.
This simplifies our behavior.