### PR TITLE
Fix supported format listed in capability statement.

### DIFF
--- a/apps/fhir/bluebutton/views/home.py
+++ b/apps/fhir/bluebutton/views/home.py
@@ -68,7 +68,7 @@ def fhir_conformance(request, via_oauth=False, *args, **kwargs):
     # Append Security to ConformanceStatement
     security_endpoint = build_oauth_resource(request, format_type="json")
     od['rest'][0]['security'] = security_endpoint
-    od['format'] = ['appliction/json']
+    od['format'] = ['application/fhir+json']
 
     return JsonResponse(od)
 

--- a/apps/fhir/bluebutton/views/home.py
+++ b/apps/fhir/bluebutton/views/home.py
@@ -68,7 +68,7 @@ def fhir_conformance(request, via_oauth=False, *args, **kwargs):
     # Append Security to ConformanceStatement
     security_endpoint = build_oauth_resource(request, format_type="json")
     od['rest'][0]['security'] = security_endpoint
-    od['format'] = ['application/fhir+json']
+    od['format'] = ['application/json', 'application/fhir+json']
 
     return JsonResponse(od)
 


### PR DESCRIPTION
The capability statement lists `appliction/json` as the supported format for the FHIR server, but that is not a valid mime type because "application" is misspelled.  I recommend using `application/fhir+json` because that is the required json mime type for STU3+ FHIR servers (see [documentation](https://www.hl7.org/fhir/http.html#mime-type)).  It is also the format that is advertised in the HAPI capability statement being overwritten (see [example HAPI capability statement](http://fhirtest.uhn.ca/baseDstu3/metadata)).

An alternative solution would be to filter the existing format field by 'json' substring, which would be a lighter touch by this proxy:

```python
# for illustration purposes only; I have limited python experience
od['format'] = list(filter(lambda f: 'json' in f, od['format']))
```
The above would support servers that are both DSTU2 and STU3, and it would also pass along `json`, which is technically a valid code (see [documentation](https://www.hl7.org/fhir/capabilitystatement-definitions.html#CapabilityStatement.format)).  This pull request does not use this method though, because I chose to stay consistent with the current approach of simply overwriting the format string.

This bug affects clients that use the capability statement to determine which formats are supported by servers, so that they can choose which encoding to use.

I was able to test this manually on my local machine by standing up a dev instance and checking `http://localhost:8000/v1/fhir/metadata`.

Please let me know if you have any questions.

Thanks!

