### PR TITLE
Tweaks to ops/build_release.sh

### DIFF
--- a/ops/build_release.sh
+++ b/ops/build_release.sh
@@ -57,6 +57,12 @@ then
   exit 1
 fi
 
+if [ ! -f "LICENSE" ]
+then
+  echo "Must run script in top-level project directory."
+  exit 1
+fi
+
 # fetch tags before any tag lookups so we have the most up-to-date list
 # and generate the correct next release number
 git fetch --tags
@@ -79,8 +85,6 @@ else
   NEWTAG="r$NEWRELEASENUM"
 fi
 
-RELEASE_NOTES="RELEASE.txt"
-[ ! -f $RELEASE_NOTES ] && echo "Must run script in top-level project directory." >&2 && exit 1
 TMPFILE=$(mktemp /tmp/$(basename $0).XXXXXX) || exit 1
 
 commits=$(git log --pretty=format:"- %s" $PREVTAG..HEAD)

--- a/ops/build_release.sh
+++ b/ops/build_release.sh
@@ -53,13 +53,13 @@ fi
 
 if [ -z "$GITHUB_ACCESS_TOKEN" ]
 then
-  echo "Please export GITHUB_ACCESS_TOKEN to continue"
+  echo "Please export GITHUB_ACCESS_TOKEN to continue">&2
   exit 1
 fi
 
 if [ ! -f "LICENSE" ]
 then
-  echo "Must run script in top-level project directory."
+  echo "Must run script in top-level project directory.">&2
   exit 1
 fi
 


### PR DESCRIPTION
Couple minor tweaks:

- Don't rely on `RELEASE.txt` to be present
- Try to determine if the script is being run from top-level directory earlier in the process
- Direct error output to stderr