### PR TITLE
BLUEBUTTON-371: Bad link shows up on api.bluebutton.cms.gov home page

### DIFF
--- a/apps/home/templates/index.html
+++ b/apps/home/templates/index.html
@@ -32,7 +32,7 @@
                                                  
                    <a class="ds-c-button button--white" href="{% url 'accounts_create_account' %}"> aria-label="Sign up for the {{ settings.APPLICATION_TITLE }}" target="_self">Sign up for the {{ settings.APPLICATION_TITLE }} &rarr;</a>
                 {% else %}
-                    <a class="ds-c-button button--white" href="{% url 'request_invite' %}"  aria-label="Sign up for the {{ settings.APPLICATION_TITLE }}" target="_self">Sign up for the {{ settings.APPLICATION_TITLE }} &rarr;</a>
+                   <a class="ds-c-button button--white" href="https://sandbox.bluebutton.cms.gov/v1/accounts/create" aria-label="Sign up for the Blue Button 2.0 Sandbox" target="_self">Sign up for the Blue Button 2.0 Sandbox &rarr</a>
                 {% endif %}
               </div>
 


### PR DESCRIPTION
Bad link shows up on api.bluebutton.cms.gov home page when not logged in.

missing ">"

Also re-direct to sandbox for signup.
