### PR TITLE
Bluebutton 427 unique app names case insensitive

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -92,7 +92,7 @@ class CustomRegisterApplicationForm(forms.ModelForm):
                                         It looks like this application name
                                         is already in use with another app.
                                         Please enter a different application
-                                        name to prevent future errors. 
+                                        name to prevent future errors.
                                         Note that names are case-insensitive.
                                         """)
         return name

--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -87,12 +87,13 @@ class CustomRegisterApplicationForm(forms.ModelForm):
     def clean_name(self):
         name = self.cleaned_data.get('name')
         app_model = get_application_model()
-        if app_model.objects.filter(name=name).exclude(pk=self.instance.pk).exists():
+        if app_model.objects.filter(name__iexact=name).exclude(pk=self.instance.pk).exists():
             raise forms.ValidationError("""
                                         It looks like this application name
                                         is already in use with another app.
                                         Please enter a different application
-                                        name to prevent future errors.
+                                        name to prevent future errors. 
+                                        Note that names are case-insensitive.
                                         """)
         return name
 

--- a/apps/dot_ext/tests/test_forms.py
+++ b/apps/dot_ext/tests/test_forms.py
@@ -1,0 +1,39 @@
+from apps.test import BaseApiTest
+from apps.dot_ext.forms import CustomRegisterApplicationForm
+
+
+class TestRegisterApplicationForm(BaseApiTest):
+    def test_update_form_edit(self):
+        """
+        """
+        read_group = self._create_group('read')
+        self._create_capability('Read-Scope', [], read_group)
+        # create user and add it to the read group
+        user = self._create_user('john', '123456')
+        user.groups.add(read_group)
+        # create an application
+        self._create_application('john_app', user=user)
+
+        # Test form with exact app name has error
+        data = {'name': 'john_app'}
+        form = CustomRegisterApplicationForm(user, data)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('name'), None)
+
+        # Test form with same app name and Uppercase has error
+        data = {'name': 'John_App'}
+        form = CustomRegisterApplicationForm(user, data)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('name'), None)
+
+        # Test form with different app name is OK
+        data = {'name': 'Dave_app'}
+        form = CustomRegisterApplicationForm(user, data)
+        form.is_valid()
+        self.assertEqual(form.errors.get('name'), None)
+
+        # Test form with empty app name has error.
+        data = {'name': ''}
+        form = CustomRegisterApplicationForm(user, data)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('name'), None)


### PR DESCRIPTION
* Change queryset for application name duplicate check to be case insensitive.

* Django tests for the 'name' field validation in the CustomRegisterApplicationForm form.