### PR TITLE
BLUEBUTTON-491 Fix links in activation email templates

### DIFF
--- a/apps/accounts/templates/email-activate.html
+++ b/apps/accounts/templates/email-activate.html
@@ -20,7 +20,7 @@
                 <p>
                     <ul>
                         <li>Ask questions and give feedback in the {{ APPLICATION_TITLE }} Google Group
-                        <a href=https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api">
+                        <a href="https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api">
                                 https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api</a></li>
                         <li>Download the Django Client App to get started
                         <a href="https://github.com/cmsgov/bluebutton-sample-client-django">

--- a/apps/accounts/templates/email-activate.html
+++ b/apps/accounts/templates/email-activate.html
@@ -23,8 +23,8 @@
                         <a href=https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api">
                                 https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api</a></li>
                         <li>Download the Django Client App to get started
-                        <a href="https://github.com/cmsgov/django_bluebutton_client">
-                            https://github.com/cmsgov/django_bluebutton_client</a></li>
+                        <a href="https://github.com/cmsgov/bluebutton-sample-client-django">
+                            https://github.com/cmsgov/bluebutton-sample-client-django</a></li>
                     </ul>
                 </p>
                 </div>

--- a/apps/accounts/templates/email-activate.txt
+++ b/apps/accounts/templates/email-activate.txt
@@ -9,7 +9,7 @@ To complete your signup, follow this link:
 Some helpful tips:
 
 - Ask questions and give feedback in the {{ APPLICATION_TITLE }} Google Group https://groups.google.com/forum/#!forum/developer-group-for-cms-blue-button-api
-- Download the Django Client App to get started https://github.com/cmsgov/django_bluebutton_client
+- Download the Django Client App to get started https://github.com/cmsgov/bluebutton-sample-client-django
 
 Thanks,
 The {{APPLICATION_TITLE}} Team


### PR DESCRIPTION
Just a few template changes to fix the links for the activation email (email sent after signup w/ activation key). 