### PR TITLE
Fix Crosswalk admin list to handle Null fhir_source

### DIFF
--- a/apps/fhir/bluebutton/admin.py
+++ b/apps/fhir/bluebutton/admin.py
@@ -15,7 +15,7 @@ class CrosswalkAdmin(admin.ModelAdmin):
     get_user_username.short_description = "User Name"
 
     def get_fhir_source(self, obj):
-        return obj.fhir_source.name
+        return getattr(obj.fhir_source, 'name', '')
 
     get_fhir_source.admin_order_field = "name"
     get_fhir_source.short_description = "Name"


### PR DESCRIPTION
This fixes the admin crosswalk list when a fhir_source attribute is NoneType.