### PR TITLE
609: Adding 'Crazy Egg' script

### DIFF
--- a/templates/design_system/base.html
+++ b/templates/design_system/base.html
@@ -34,6 +34,5 @@
 
     <script>window.tealiumEnvironment = "{{ settings.TEALIUM_ENV }}";</script>
     <script src="//tags.tiqcdn.com/utag/cmsgov/cms-bluebutton/{{ settings.TEALIUM_ENV }}/utag.sync.js"></script>
-		<script type="text/javascript" src="//script.crazyegg.com/pages/scripts/0078/9905.js" async="async"></script>
 </body>
 </html>

--- a/templates/include/foot.html
+++ b/templates/include/foot.html
@@ -18,3 +18,5 @@
         {% endif %}
     <script>window.tealiumEnvironment = "{{ settings.TEALIUM_ENV }}";</script>
     <script src="//tags.tiqcdn.com/utag/cmsgov/cms-bluebutton/{{ settings.TEALIUM_ENV }}/utag.sync.js"></script>
+    <!-- Crazy Egg Load -->
+    <script type="text/javascript"src="//script.crazyegg.com/pages/scripts/0078/9905.js"async="async"></script>


### PR DESCRIPTION
Previously crazy egg was placed within the design-system base.html - In this PR I'm placing it in foot.html (at the end) which is loaded by template/base.html - Pulling this in at the bottom should keep page loads snappy and it's where other scripts are referenced as well.