### PR TITLE
BLUEBUTTON-633 Remaining Bootstrap Removal Fixes

### DIFF
--- a/apps/accounts/templates/account-settings.html
+++ b/apps/accounts/templates/account-settings.html
@@ -8,14 +8,16 @@
 
       <h1>{{name}} <small>{{subname}}</small></h1>
 
-      <!-- Password Update Button -->
-      <a class="ds-c-button  ds-c-button--default" href="{% url 'reset_password' %}">
-        Change Your Password
-      </a>
-      <!-- Secret Question Update Button -->
-      <a class="ds-c-button  ds-c-button--default" href="{% url 'change_secret_questions' %}">
-        Change You Secret Questions and Answers
-      </a>
+      <div class="ds-u-margin-y--2">
+        <!-- Password Update Button -->
+        <a class="ds-c-button  ds-c-button--default" href="{% url 'reset_password' %}">
+          Change Your Password
+        </a>
+        <!-- Secret Question Update Button -->
+        <a class="ds-c-button  ds-c-button--default" href="{% url 'change_secret_questions' %}">
+          Change Your Secret Questions and Answers
+        </a>
+      </div>
 
       {% if additional_info %}
         <div class="alert alert-info">

--- a/templates/generic/bootstrapform.html
+++ b/templates/generic/bootstrapform.html
@@ -2,9 +2,8 @@
 {% load i18n %}
 {% block Content %}
 
-<div class="ds-l-row ds-u-justify-content--center ds-u-margin-y--7 sandbox-login-container">
-
-  <div class="ds-l-lg-col--6 ds-l-md-col--8 ds-l-sm-col--12">
+<div class="ds-l-row ds-u-justify-content--center ds-u-margin-y--4 ds-u-margin-x--1">
+  <div class="ds-l-col--12 ds-l-sm-col--12 ds-l-md-col--8 ds-l-lg-col--7 ds-l-xl-col--7">
     <div class="ds-u-margin-bottom--4">
       <h1>{{name}} <small>{{subname}}</small></h1>
       <small>* Required Fields</small>

--- a/templates/include/messages.html
+++ b/templates/include/messages.html
@@ -1,4 +1,4 @@
-<div id="messages">
+<!-- <div id="messages">
         {% if messages %}
           {% for message in messages %}
             <div class="alert alert-{{message.tags}}">
@@ -7,4 +7,17 @@
             </div>
           {% endfor %}
         {% endif %}
+</div> -->
+
+<div id="messages">
+{% if messages %}
+  {% for message in messages %}
+  <div class="ds-c-alert alert-{{message.tags}}">
+    <!-- <a class="close" data-dismiss="alert">×</a> -->
+    <div class="ds-c-alert__text">
+      {{message}}
+    </div>
+  </div>
+  {% endfor %}
+{% endif %}
 </div>

--- a/templates/include/messages.html
+++ b/templates/include/messages.html
@@ -1,14 +1,3 @@
-<!-- <div id="messages">
-        {% if messages %}
-          {% for message in messages %}
-            <div class="alert alert-{{message.tags}}">
-              <a class="close" data-dismiss="alert">×</a>
-              {{message}}
-            </div>
-          {% endfor %}
-        {% endif %}
-</div> -->
-
 <div id="messages">
 {% if messages %}
   {% for message in messages %}


### PR DESCRIPTION
This fixes some of the last bugs that Cat found with the Bootstrap removal.
- Makes the Signup page properly responsive.
- Switches the "top-of-page" errors/messages to follow CMS Design system instead of Bootstrap.

Here is an example of the updated message:

![screenshot_2018-12-31 blue button 2 0 dev 1](https://user-images.githubusercontent.com/5551607/50564722-76227000-0cf5-11e9-8644-ba6ac549519d.png)
