### PR TITLE
BLUEBUTTON-862 Make applications list public on next release to PROD

### DIFF
--- a/apps/wellknown/urls.py
+++ b/apps/wellknown/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from waffle.decorators import waffle_switch
 from .views import openid_configuration, ApplicationListView
 
 
@@ -6,5 +7,7 @@ urlpatterns = [
     url(r'^openid-configuration$',
         openid_configuration,
         name='openid-configuration'),
-    url(r'^applications$', ApplicationListView.as_view(), name='applications-list'),
+    url(r'^applications$',
+        waffle_switch('wellknown_applications')(ApplicationListView.as_view()),
+        name='applications-list'),
 ]


### PR DESCRIPTION
Summary:

This adds a feature switch called "wellknown_applications" to control enabling and disabling of the /.well-known/applications endpoint. If this switch is missing, the default is to disable the endpoint.

NOTE: This was previously controlled via the deployment repository and NGINX configuration using IP address range restrictions.