### PR TITLE
Create waffle switches for local development testing

### DIFF
--- a/apps/core/management/commands/create_test_feature_switches.py
+++ b/apps/core/management/commands/create_test_feature_switches.py
@@ -2,21 +2,24 @@ from django.core.management.base import BaseCommand
 from waffle.models import Switch
 
 
+WAFFLE_FEATURE_SWITCHES = (('outreach_email', True),
+                           ('wellknown_applications', True),
+                           ('login', True),
+                           ('signup', True))
+
+
 class Command(BaseCommand):
     help = 'Create Feature Switches for Local Testing'
 
     def handle(self, *args, **options):
         # Create feature switches for testing in local development
-        for switch in [['outreach_email', True],
-                       ['wellknown_applications', True],
-                       ['login', True],
-                       ['signup', True]]:
+        for switch in WAFFLE_FEATURE_SWITCHES:
             try:
                 Switch.objects.get(name=switch[0])
-                self._log('Feature switch already exists: %s' % (switch))
+                self._log('Feature switch already exists: %s' % (str(switch)))
             except Switch.DoesNotExist:
                 Switch.objects.create(name=switch[0], active=switch[1])
-                self._log('Feature switch created: %s' % (switch))
+                self._log('Feature switch created: %s' % (str(switch)))
 
     def _log(self, message):
         self.stdout.write(message)

--- a/apps/core/management/commands/create_test_feature_switches.py
+++ b/apps/core/management/commands/create_test_feature_switches.py
@@ -1,0 +1,22 @@
+from django.core.management.base import BaseCommand
+from waffle.models import Switch
+
+
+class Command(BaseCommand):
+    help = 'Create Feature Switches for Local Testing'
+
+    def handle(self, *args, **options):
+        # Create feature switches for testing in local development
+        for switch in [['outreach_email', True],
+                       ['wellknown_applications', True],
+                       ['login', True],
+                       ['signup', True]]:
+            try:
+                Switch.objects.get(name=switch[0])
+                self._log('Feature switch already exists: %s' % (switch))
+            except Switch.DoesNotExist:
+                Switch.objects.create(name=switch[0], active=switch[1])
+                self._log('Feature switch created: %s' % (switch))
+
+    def _log(self, message):
+        self.stdout.write(message)

--- a/docker-compose/migrate.sh
+++ b/docker-compose/migrate.sh
@@ -7,3 +7,4 @@ python manage.py create_admin_groups
 python manage.py create_blue_button_scopes
 python manage.py setup_bluebutton
 python manage.py create_test_user_and_application
+python manage.py create_test_feature_switches


### PR DESCRIPTION
Since we've added the use of Waffle feature switches to the project, they all default to False when running locally via the docker-compose setup. So features like login and signup are disabled until the related switch is created.

This PR creates a management command that is called via the docker-compose/migrate.sh script. This command creates the switches during setup so that this doesn't need to be done manually via ADMIN.
