### PR TITLE
BLUEBUTTON-903 Create app category labels endpoint

### DIFF
--- a/apps/wellknown/urls.py
+++ b/apps/wellknown/urls.py
@@ -1,6 +1,6 @@
 from django.conf.urls import url
 from waffle.decorators import waffle_switch
-from .views import openid_configuration, ApplicationListView
+from .views import openid_configuration, ApplicationListView, ApplicationLabelView
 
 
 urlpatterns = [
@@ -10,4 +10,7 @@ urlpatterns = [
     url(r'^applications$',
         waffle_switch('wellknown_applications')(ApplicationListView.as_view()),
         name='applications-list'),
+    url(r'^application-labels$',
+        waffle_switch('wellknown_applications')(ApplicationLabelView.as_view()),
+        name='application-labels'),
 ]

--- a/apps/wellknown/views/__init__.py
+++ b/apps/wellknown/views/__init__.py
@@ -1,2 +1,2 @@
 from .openid import openid_configuration, base_issuer, build_endpoint_info  # NOQA
-from .application import ApplicationListView  # NOQA
+from .application import ApplicationListView, ApplicationLabelView  # NOQA

--- a/apps/wellknown/views/application.py
+++ b/apps/wellknown/views/application.py
@@ -3,7 +3,7 @@ from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONRenderer
-from ...dot_ext.models import Application, ApplicationLabel
+from apps.dot_ext.models import Application, ApplicationLabel
 from ..serializers import ApplicationListSerializer, ApplicationLabelSerializer
 
 

--- a/apps/wellknown/views/application.py
+++ b/apps/wellknown/views/application.py
@@ -1,10 +1,10 @@
-from ...dot_ext.models import Application
-from ..serializers import ApplicationListSerializer
 from django.conf import settings
 from rest_framework.generics import ListAPIView
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import AllowAny
 from rest_framework.renderers import JSONRenderer
+from ...dot_ext.models import Application, ApplicationLabel
+from ..serializers import ApplicationListSerializer, ApplicationLabelSerializer
 
 
 class ApplicationListPagination(PageNumberPagination):
@@ -28,4 +28,21 @@ class ApplicationListView(ListAPIView):
     def get_queryset(self):
         queryset = Application.objects.exclude(active=False).exclude(
             applicationlabel__slug__in=settings.APP_LIST_EXCLUDE).order_by('name')
+        return queryset
+
+
+class ApplicationLabelView(ListAPIView):
+    """
+    View to provide an application labels list.
+
+    An application label that has a label slug in the APP_LIST_EXCLUDE
+    list will be excluded from this view.
+    """
+    permission_classes = (AllowAny,)
+    renderer_classes = (JSONRenderer,)
+    serializer_class = ApplicationLabelSerializer
+
+    def get_queryset(self):
+        queryset = ApplicationLabel.objects.exclude(
+            slug__in=settings.APP_LIST_EXCLUDE).order_by('name')
         return queryset


### PR DESCRIPTION
Summary:
This lists out application category labels at the following endpoint:  /.wellknown/application-labels
Label slugs in the settings.DJANGO_APP_LIST_EXCLUDE list are excluded from the listing.
The endpoint is attached to the feature switch = "wellknown_applications" .