### PR TITLE
BLUEBUTTON-919 Remove app description validations from ADMIN

### DIFF
--- a/apps/dot_ext/admin.py
+++ b/apps/dot_ext/admin.py
@@ -22,9 +22,9 @@ class MyApplication(Application):
 
 
 class CustomAdminApplicationForm(CustomRegisterApplicationForm):
-    description_input = forms.CharField(label="Application Description",
-                                        help_text="Note text size and HTML tags are not validated under ADMIN.",
-                                        widget=forms.Textarea, empty_value='', required=False)
+    description = forms.CharField(label="Application Description",
+                                  help_text="Note text size and HTML tags are not validated under ADMIN.",
+                                  widget=forms.Textarea, empty_value='', required=False)
 
     def __init__(self, *args, **kwargs):
         user = None
@@ -56,7 +56,7 @@ class CustomAdminApplicationForm(CustomRegisterApplicationForm):
             'contacts',
             'support_email',
             'support_phone_number',
-            'description_input',
+            'description',
             'active',
             'first_active',
             'last_active',

--- a/apps/dot_ext/admin.py
+++ b/apps/dot_ext/admin.py
@@ -1,5 +1,5 @@
+from django import forms
 from django.contrib import admin
-from django.forms import ModelForm, CharField, Textarea
 from oauth2_provider.models import AccessToken
 from oauth2_provider.models import get_application_model
 from .forms import CustomRegisterApplicationForm
@@ -22,13 +22,14 @@ class MyApplication(Application):
 
 
 class CustomAdminApplicationForm(CustomRegisterApplicationForm):
-    description_input = CharField(label="Application Description",
-                                  help_text="Note text size and HTML tags are not validated under ADMIN.",
-                                  widget=Textarea, empty_value='', required=False)
+    description_input = forms.CharField(label="Application Description",
+                                        help_text="Note text size and HTML tags are not validated under ADMIN.",
+                                        widget=forms.Textarea, empty_value='', required=False)
 
     def __init__(self, *args, **kwargs):
-        super(ModelForm, self).__init__(*args, **kwargs)
-        self.fields['description_input'].initial = self.instance.description
+        user = None
+        super().__init__(user, *args, **kwargs)
+        self.fields['logo_uri'].widget.attrs['readonly'] = False
 
     class Meta:
         model = MyApplication
@@ -64,24 +65,8 @@ class CustomAdminApplicationForm(CustomRegisterApplicationForm):
     def clean(self):
         return self.cleaned_data
 
-    def clean_name(self):
-        return super().clean_name()
-
     def clean_agree(self):
         return self.cleaned_data.get('agree')
-
-    def clean_redirect_uris(self):
-        return self.cleaned_data.get('redirect_uris')
-
-    def clean_logo_image(self):
-        return super().clean_logo_image()
-
-    def clean_description_input(self):
-        return self.cleaned_data.get('description_input')
-
-    def save(self, *args, **kwargs):
-        self.instance.description = self.cleaned_data.get('description_input')
-        return super().save(*args, **kwargs)
 
 
 class MyApplicationAdmin(admin.ModelAdmin):

--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -20,7 +20,7 @@ class CustomRegisterApplicationForm(forms.ModelForm):
                                   % (settings.APP_LOGO_SIZE_MAX, settings.APP_LOGO_WIDTH_MAX,
                                      settings.APP_LOGO_HEIGHT_MAX))
 
-    description_input = forms.CharField(label="Application Description",
+    description = forms.CharField(label="Application Description",
                                         help_text="This is plain-text up to 1000 characters in length.",
                                         widget=forms.Textarea, empty_value='', required=False,
                                         max_length=1000, validators=[validate_notags])
@@ -38,7 +38,6 @@ class CustomRegisterApplicationForm(forms.ModelForm):
         self.fields['authorization_grant_type'].label = "Authorization Grant Type*"
         self.fields['redirect_uris'].label = "Redirect URIs*"
         self.fields['logo_uri'].widget.attrs['readonly'] = True
-        self.fields['description_input'].initial = self.instance.description
 
     class Meta:
         model = get_application_model()
@@ -50,7 +49,7 @@ class CustomRegisterApplicationForm(forms.ModelForm):
             'logo_uri',
             'logo_image',
             'website_uri',
-            'description_input',
+            'description',
             'policy_uri',
             'tos_uri',
             'support_email',
@@ -142,7 +141,6 @@ class CustomRegisterApplicationForm(forms.ModelForm):
         return logo_image
 
     def save(self, *args, **kwargs):
-        self.instance.description = self.cleaned_data.get('description_input')
         app = self.instance
         # Only log agreement from a Register form
         if app.agree and type(self) == CustomRegisterApplicationForm:

--- a/apps/dot_ext/models.py
+++ b/apps/dot_ext/models.py
@@ -17,7 +17,6 @@ from oauth2_provider.models import (
 )
 from oauth2_provider.settings import oauth2_settings
 from django.conf import settings
-from apps.dot_ext.validators import validate_notags
 from django.template.defaultfilters import truncatechars
 from django.core.files.storage import default_storage
 
@@ -73,10 +72,8 @@ class Application(AbstractApplication):
         blank=True,
         null=True)
 
-    description = models.TextField(default="", blank=True, null=True, max_length=1000,
-                                   verbose_name="Application Description",
-                                   help_text="This is plain-text up to 1000 characters in length.",
-                                   validators=[validate_notags])
+    description = models.TextField(default="", blank=True, null=True, verbose_name="Application Description",
+                                   help_text="This is plain-text up to 1000 characters in length.")
     active = models.BooleanField(default=True)
     first_active = models.DateTimeField(blank=True, null=True)
     last_active = models.DateTimeField(blank=True, null=True)

--- a/apps/dot_ext/tests/test_forms.py
+++ b/apps/dot_ext/tests/test_forms.py
@@ -1,9 +1,12 @@
-from apps.test import BaseApiTest
-from apps.dot_ext.forms import CustomRegisterApplicationForm
+from django.conf import settings
+from django.core.files.uploadedfile import InMemoryUploadedFile
+
 from PIL import Image
 from io import BytesIO
-from django.core.files.uploadedfile import InMemoryUploadedFile
-from django.conf import settings
+
+from apps.test import BaseApiTest
+from apps.dot_ext.forms import CustomRegisterApplicationForm
+from apps.dot_ext.admin import CustomAdminApplicationForm
 
 
 class TestRegisterApplicationForm(BaseApiTest):
@@ -21,6 +24,10 @@ class TestRegisterApplicationForm(BaseApiTest):
         # Test form with exact app name has error
         data = {'name': 'john_app'}
         form = CustomRegisterApplicationForm(user, data)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('name'), None)
+
+        form = CustomAdminApplicationForm(data)
         form.is_valid()
         self.assertNotEqual(form.errors.get('name'), None)
 
@@ -61,34 +68,51 @@ class TestRegisterApplicationForm(BaseApiTest):
         self.assertEqual(form.errors.get('website_uri'), None)
 
         # Test form with empty description.
-        data = {'description': ''}
+        data = {'description_input': ''}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description'), None)
+        self.assertEqual(form.errors.get('description_input'), None)
+
+        form = CustomAdminApplicationForm(data)
+        form.is_valid()
+        self.assertEqual(form.errors.get('description_input'), None)
 
         # Test form with valid description.
-        data = {'description': 'Testing short description here!'}
+        data = {'description_input': 'Testing short description here!'}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description'), None)
+        self.assertEqual(form.errors.get('description_input'), None)
+
+        form = CustomAdminApplicationForm(data)
+        form.is_valid()
+        self.assertEqual(form.errors.get('description_input'), None)
 
         # Test form with description over 1000 characters.
-        data = {'description': 'T' * 1001}
+        data = {'description_input': 'T' * 1001}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertNotEqual(form.errors.get('description'), None)
+        self.assertNotEqual(form.errors.get('description_input'), None)
+
+        form = CustomAdminApplicationForm(data)
+        form.is_valid()
+        self.assertEqual(form.errors.get('description_input'), None)
 
         # Test form with description exactly 1000 characters.
-        data = {'description': 'T' * 1000}
+        data = {'description_input': 'T' * 1000}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description'), None)
+        self.assertEqual(form.errors.get('description_input'), None)
 
         # Test form with HTML tags in the description.
-        data = {'description': '<b>Test</b> <button>Test</button> a <span>Test</span>'}
+        data = {'description_input': '<b>Test</b> <button>Test</button> a <span>Test</span>'}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertNotEqual(form.errors.get('description'), None)
+        self.assertNotEqual(form.errors.get('description_input'), None)
+
+        form = CustomAdminApplicationForm(data)
+        form.is_valid()
+        self.assertEqual(form.errors.get('description_input'), None)
+
 
         # Testing valid logo_image with max dimensions
         file = BytesIO()
@@ -120,6 +144,10 @@ class TestRegisterApplicationForm(BaseApiTest):
         form.is_valid()
         self.assertNotEqual(form.errors.get('logo_image'), None)
 
+        form = CustomAdminApplicationForm(data, files)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('logo_image'), None)
+
         # Testing logo_image exceeding max height
         file = BytesIO()
         image = Image.new('RGB', size=(int(settings.APP_LOGO_WIDTH_MAX),
@@ -135,6 +163,10 @@ class TestRegisterApplicationForm(BaseApiTest):
         form.is_valid()
         self.assertNotEqual(form.errors.get('logo_image'), None)
 
+        form = CustomAdminApplicationForm(data, files)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('logo_image'), None)
+
         # Testing logo_image not JPEG type
         file = BytesIO()
         image = Image.new('RGB', size=(50, 50), color='red')
@@ -146,5 +178,9 @@ class TestRegisterApplicationForm(BaseApiTest):
         data = {}
         files = {'logo_image': image}
         form = CustomRegisterApplicationForm(user, data, files)
+        form.is_valid()
+        self.assertNotEqual(form.errors.get('logo_image'), None)
+
+        form = CustomAdminApplicationForm(data, files)
         form.is_valid()
         self.assertNotEqual(form.errors.get('logo_image'), None)

--- a/apps/dot_ext/tests/test_forms.py
+++ b/apps/dot_ext/tests/test_forms.py
@@ -68,51 +68,50 @@ class TestRegisterApplicationForm(BaseApiTest):
         self.assertEqual(form.errors.get('website_uri'), None)
 
         # Test form with empty description.
-        data = {'description_input': ''}
+        data = {'description': ''}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
+        self.assertEqual(form.errors.get('description'), None)
 
         form = CustomAdminApplicationForm(data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
+        self.assertEqual(form.errors.get('description'), None)
 
         # Test form with valid description.
-        data = {'description_input': 'Testing short description here!'}
+        data = {'description': 'Testing short description here!'}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
+        self.assertEqual(form.errors.get('description'), None)
 
         form = CustomAdminApplicationForm(data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
+        self.assertEqual(form.errors.get('description'), None)
 
         # Test form with description over 1000 characters.
-        data = {'description_input': 'T' * 1001}
+        data = {'description': 'T' * 1001}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertNotEqual(form.errors.get('description_input'), None)
+        self.assertNotEqual(form.errors.get('description'), None)
 
         form = CustomAdminApplicationForm(data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
+        self.assertEqual(form.errors.get('description'), None)
 
         # Test form with description exactly 1000 characters.
-        data = {'description_input': 'T' * 1000}
+        data = {'description': 'T' * 1000}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
+        self.assertEqual(form.errors.get('description'), None)
 
         # Test form with HTML tags in the description.
-        data = {'description_input': '<b>Test</b> <button>Test</button> a <span>Test</span>'}
+        data = {'description': '<b>Test</b> <button>Test</button> a <span>Test</span>'}
         form = CustomRegisterApplicationForm(user, data)
         form.is_valid()
-        self.assertNotEqual(form.errors.get('description_input'), None)
+        self.assertNotEqual(form.errors.get('description'), None)
 
         form = CustomAdminApplicationForm(data)
         form.is_valid()
-        self.assertEqual(form.errors.get('description_input'), None)
-
+        self.assertEqual(form.errors.get('description'), None)
 
         # Testing valid logo_image with max dimensions
         file = BytesIO()


### PR DESCRIPTION
This removes the text size and HTML tag validations on the application description when editing via the Django ADMIN. 
