### PR TITLE
BLUEBUTTON-937 Disable email field in AccountSettingsForm

### DIFF
--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -3,6 +3,7 @@ from django.conf import settings
 from django import forms
 from django.contrib.auth.forms import UserCreationForm
 from django.contrib.auth.models import User, Group
+from django.db.models import Q
 from django.utils.translation import ugettext_lazy as _
 from apps.fhir.bluebutton.models import Crosswalk
 from apps.fhir.bluebutton.utils import get_resourcerouter
@@ -47,9 +48,7 @@ class SignupForm(UserCreationForm):
     def clean_email(self):
         email = self.cleaned_data.get('email', "")
         if email:
-            username = self.cleaned_data.get('username')
-            if email and User.objects.filter(email=email).exclude(
-                    username=username).count():
+            if User.objects.filter(Q(email=email) | Q(username=email)).exists():
                 raise forms.ValidationError(
                     _('This email address is already registered.'))
             return email.rstrip().lstrip().lower()

--- a/apps/accounts/forms.py
+++ b/apps/accounts/forms.py
@@ -86,7 +86,7 @@ class AccountSettingsForm(forms.Form):
         self.request = kwargs.pop("request")
         super(AccountSettingsForm, self).__init__(*args, **kwargs)
 
-    email = forms.EmailField(max_length=255, label=_('Email'))
+    email = forms.EmailField(max_length=255, label=_('Email'), disabled=True, required=False)
     first_name = forms.CharField(max_length=100, label=_('First Name'))
     last_name = forms.CharField(max_length=100, label=_('Last Name'))
     mfa_login_mode = forms.ChoiceField(required=False,
@@ -106,15 +106,6 @@ class AccountSettingsForm(forms.Form):
         if self.request.user.is_staff and not mfa_login_mode:
             raise forms.ValidationError(_('MFA is not optional for staff.'))
         return mfa_login_mode
-
-    def clean_email(self):
-        email = self.cleaned_data.get('email')
-        if email:
-            if email and User.objects.filter(
-                    email=email).exclude(email=email).count():
-                raise forms.ValidationError(_('This email address is '
-                                              'already registered.'))
-        return email.rstrip().lstrip().lower()
 
 
 class AuthenticationForm(AuthenticationForm):

--- a/apps/accounts/tests/test_case_ins_username.py
+++ b/apps/accounts/tests/test_case_ins_username.py
@@ -11,48 +11,44 @@ class CheckCaseInsensitiveUsernameTestCase(TestCase):
     """
 
     def setUp(self):
-        u = User.objects.create_user(username="fred",
+        u = User.objects.create_user(username="fred@example.com",
                                      first_name="Fred",
                                      last_name="Flinstone",
                                      email='fred@example.com',
                                      password="foobar",)
         UserProfile.objects.create(user=u,
                                    user_type="DEV",
-                                   create_applications=True,
-                                   password_reset_question_1='1',
-                                   password_reset_answer_1='blue',
-                                   password_reset_question_2='2',
-                                   password_reset_answer_2='Frank',
-                                   password_reset_question_3='3',
-                                   password_reset_answer_3='Bentley')
+                                   create_applications=True)
         self.client = Client()
 
     def test_page_loads(self):
-        self.client.login(username="fred", password="foobar")
+        self.client.login(username="fred@example.com", password="foobar")
         url = reverse('account_settings')
         response = self.client.get(url, follow=True)
         self.assertEqual(response.status_code, 200)
 
     def test_all_fields_required(self):
-        self.client.login(username="fred", password="foobar")
+        self.client.login(username="fred@example.com", password="foobar")
         url = reverse('account_settings')
         form_data = {'username': '',
+                     'email': 'fred@example.com',
                      'first_name': '',
                      'last_name': "",
-                     'email': 'fred@example.com',
+                     'organization_name': "Flinstone INC.",
                      }
         response = self.client.post(url, form_data, follow=True)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, 'This field is required.')
 
     def test_username_forced_to_lower(self):
-        self.client.login(username="fred", password="foobar")
+        self.client.login(username="fred@example.com", password="foobar")
         url = reverse('account_settings')
-        form_data = {'username': 'FRED',
+        form_data = {'username': 'FRED@Example.com',
+                     'email': 'fred@example.com',
                      'first_name': 'Fred',
                      'last_name': "Flinstone",
-                     'email': 'fred@example.com',
+                     'organization_name': "Flinstone INC.",
                      }
         response = self.client.post(url, form_data, follow=True)
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, 'fred')
+        self.assertContains(response, 'fred@example.com')

--- a/apps/accounts/views/core.py
+++ b/apps/accounts/views/core.py
@@ -56,7 +56,6 @@ def account_settings(request):
         if form.is_valid():
             data = form.cleaned_data
             # update the user info
-            request.user.email = data['email']
             request.user.first_name = data['first_name']
             request.user.last_name = data['last_name']
             request.user.save()

--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -37,7 +37,7 @@ class CustomRegisterApplicationForm(forms.ModelForm):
         self.fields['client_type'].label = "Client Type*"
         self.fields['authorization_grant_type'].label = "Authorization Grant Type*"
         self.fields['redirect_uris'].label = "Redirect URIs*"
-        self.fields['logo_uri'].widget.attrs['readonly'] = True
+        self.fields['logo_uri'].disabled = True
 
     class Meta:
         model = get_application_model()


### PR DESCRIPTION
NOTE: I also changed the logo_uri field in the application registration form to use the field disabled=True option versus using the widget's "readonly" attribute. This is a better method and prevents the ability to update the field via client side tampering.