### PR TITLE
BLUEBUTTON-938 dpr switch in test

### DIFF
--- a/apps/metrics/urls.py
+++ b/apps/metrics/urls.py
@@ -11,6 +11,7 @@ from .views import (
     DataAccessGrantView,
     ArchivedDataAccessGrantView,
     CheckDataAccessGrantsView,
+    CheckCrosswalksView,
 )
 
 admin.autodiscover()
@@ -19,6 +20,7 @@ urlpatterns = [
     url(r'^beneficiaries$', BeneMetricsView.as_view(), name='beneficiaries'),
     url(r'^applications/(?P<pk>\d+)$', AppMetricsDetailView.as_view(), name='applications-detail'),
     url(r'^applications/$', AppMetricsView.as_view(), name='applications'),
+    url(r'^crosswalks/check$', CheckCrosswalksView.as_view(), name='check-crosswalks'),
     url(r'^developers/$', DevelopersView.as_view(), name='developers'),
     url(r'^tokens$', TokenMetricsView.as_view(), name='tokens'),
     url(r'^tokens/archive$', ArchivedTokenView.as_view(), name='archived-tokens'),

--- a/apps/metrics/views.py
+++ b/apps/metrics/views.py
@@ -32,7 +32,10 @@ from apps.authorization.models import (
     check_grants,
     update_grants)
 from apps.dot_ext.models import Application, ArchivedToken
-from apps.fhir.bluebutton.models import Crosswalk
+from apps.fhir.bluebutton.models import (
+    Crosswalk,
+    check_crosswalks,
+    update_crosswalks)
 
 
 log = logging.getLogger('hhs_server.%s' % __name__)
@@ -328,6 +331,19 @@ class CheckDataAccessGrantsView(APIView):
 
     def post(self, request, format=None):
         return Response(update_grants())
+
+
+class CheckCrosswalksView(APIView):
+    permission_classes = [
+        IsAuthenticated,
+        IsAdminUser,
+    ]
+
+    def get(self, request, format=None):
+        return Response(check_crosswalks())
+
+    def post(self, request, format=None):
+        return Response(update_crosswalks())
 
 
 class AppMetricsView(ListAPIView):

--- a/templates/admin/bluebutton/crosswalk/change_list_object_tools.html
+++ b/templates/admin/bluebutton/crosswalk/change_list_object_tools.html
@@ -1,0 +1,17 @@
+{% load i18n admin_urls %}
+
+{% block object-tools-items %}
+  {% if has_add_permission %}
+  <li>
+    {% url cl.opts|admin_urlname:'add' as add_url %}
+    <a href="{% add_preserved_filters add_url is_popup to_field %}" class="addlink">
+        {% blocktrans with cl.opts.verbose_name as name %}Add {{ name }}{% endblocktrans %}
+    </a>
+  </li>
+  <li>
+    <a href="{% url 'check-crosswalks' %}">
+        Check Crosswalks
+    </a>
+  </li>
+  {% endif %}
+{% endblock %}


### PR DESCRIPTION
Summary:

* This adds an action to the crosswalks ADMIN for migrating positive fhir_id's to negative values. 
* Only crosswalks that have a resource router fhir_url that hashes to match the ALLOWED_FHIR_URL_HASH can be updated.
* The functionality is also protected by needed the "admin_crosswalk_dpr_sync" feature switch for the action to show in the ADMIN.
* The crosswalk's user_id_hash does not get updated during the migration.
