### PR TITLE
ensure health endpoints are from the root

### DIFF
--- a/hhs_oauth_server/urls.py
+++ b/hhs_oauth_server/urls.py
@@ -15,8 +15,8 @@ ADMIN_REDIRECTOR = getattr(settings, 'ADMIN_PREPEND_URL', '')
 
 
 urlpatterns = [
-    url(r'health', include('apps.health.urls')),
-    url(r'.well-known/', include('apps.wellknown.urls')),
+    url(r'^health', include('apps.health.urls')),
+    url(r'^.well-known/', include('apps.wellknown.urls')),
     url(r'^v1/accounts/', include('apps.accounts.urls')),
     url(r'^v1/connect/userinfo', openidconnect_userinfo, name='openid_connect_userinfo'),
     url(r'^v1/fhir/metadata$', fhir_conformance, name='fhir_conformance_metadata'),


### PR DESCRIPTION
Only <base url>/health<etc> should reach the health endpoints.

This updates the url specifications to require `/health` to be at the beginning of the url path to reach the health endpoints.