### PR TITLE
Claim type filter

### DIFF
--- a/apps/fhir/bluebutton/views/generic.py
+++ b/apps/fhir/bluebutton/views/generic.py
@@ -89,7 +89,10 @@ class FhirDataView(APIView):
 
         logger.debug('FHIR URL with key:%s' % target_url)
 
-        get_parameters = {**self.filter_parameters(request), **self.build_parameters(request)}
+        try:
+            get_parameters = {**self.filter_parameters(request), **self.build_parameters(request)}
+        except voluptuous.error.Invalid as e:
+            raise exceptions.ParseError(detail=e.msg)
 
         logger.debug('Here is the URL to send, %s now add '
                      'GET parameters %s' % (target_url, get_parameters))

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -5,6 +5,7 @@ from voluptuous import (
     All,
     Range,
     Coerce,
+    Any,
 )
 from rest_framework import (permissions)
 
@@ -33,6 +34,25 @@ class SearchView(FhirDataView):
     query_schema = {
         Required('startIndex', default=0): Coerce(int),
         Required('_count', default=DEFAULT_PAGE_SIZE): All(Coerce(int), Range(min=0, max=MAX_PAGE_SIZE)),
+        'type': Any(
+            'carrier',
+            'pde',
+            'dme',
+            'hha',
+            'hospice',
+            'inpatient',
+            'outpatient',
+            'snf',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|carrier',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|pde',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|dme',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|hha',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|hospice',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|inpatient',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|outpatient',
+            'https://bluebutton.cms.gov/resources/codesystem/eob-type|snf',
+        ),
     }
 
     def build_parameters(self, request, *args, **kwargs):


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

Allow `type` query param

Allowed values are specified by:
- https://bluebutton.cms.gov/resources/codesystem/eob-type
- https://confluence.cms.gov/pages/viewpage.action?spaceKey=BB&title=Allowing+3rd+parties+to+filter+EoB+Searches+by+Type

Respond to incorrect query params with a 400 

### Acceptance Validation

<!-- What should reviewers look for to determine completeness -->
Described behavior that appears to implement:
- `type` is an allowed query parameter.
- limit `type` values to allowed set.
- return an error if the values are outside of that set.

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
A sanity check for values in addition to usual review standards.

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-1065](https://jira.cms.gov/browse/BLUEBUTTON-1065)

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

- [ ] new software dependencies

<!-- If yes, list the new dependencies and briefly note any relevant security impacts -->

- [x] altered security controls
<!-- If yes, what security controls or supporting software are affected? -->
New query params and values will be passed back to the FHIR server. See description for specification.

- [X] new data stored or transmitted

<!-- If yes, what new data are we storing or transmitting? Is the data considered PII/PHI? -->
See above

- [ ] security checklist is completed for this change

<!-- If yes, provide a link to the security checklist in Confluence here. -->

- [ ] requires more information or team discussion to evaluate security implications
<!-- Use this to indicate you're unsure how this change may impact system security and would like to solicit the team's feedback. Optionally, provide background information regarding your questions and concerns. -->

