### PR TITLE
BLUEBUTTON-1334 Error Message Styling

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -79,12 +79,6 @@ class CustomRegisterApplicationForm(forms.ModelForm):
             msg += 'A confidential client may not ' \
                    'request an implicit grant type.'
 
-        # Confidential clients cannot use implicit authorization_grant_type
-        if client_type == 'confidential' and authorization_grant_type == 'implicit':
-            validate_error = True
-            msg += 'A confidential client may not ' \
-                   'request an implicit grant type.'
-
         if validate_error:
             msg_output = _(msg)
             raise forms.ValidationError(msg_output)

--- a/apps/dot_ext/templates/oauth2_provider/application_form.html
+++ b/apps/dot_ext/templates/oauth2_provider/application_form.html
@@ -3,49 +3,71 @@
 {% load i18n %}
 
 {% block bannerBackButton %}
-  <a class="banner-back-button" href="{% block app-form-back-url %}{% url "oauth2_provider:detail" application.id %}{% endblock app-form-back-url %}"><i data-feather="arrow-left"></i>{% trans "Go Back" %}</a>
+	<a class="banner-back-button" href="{% block app-form-back-url %}{% url "oauth2_provider:detail" application.id %}{% endblock app-form-back-url %}">
+		<i data-feather="arrow-left"></i>{% trans "Go Back" %}</a>
 {% endblock %}
 
 {% block bannerTitle %}
-  {% block app-form-title %}
-    {% trans "Edit" %} {{ application.name }}
-  {% endblock app-form-title %}
+	{% block app-form-title %}
+		{% trans "Edit" %}
+		{{ application.name }}
+	{% endblock app-form-title %}
 {% endblock %}
 
-{% block bannerDescription %}
+{% block bannerDescription %}{% endblock %}
 
-{% endblock %}
-
-{% block bannerCallToActionButtons %}
-
-{% endblock %}
+{% block bannerCallToActionButtons %}{% endblock %}
 
 {% block content %}
-<!-- CI_TESTING:START -->
-<!-- test_dot_ext_application_registration -->
-<!-- CI_TESTING:END -->
+	<!-- CI_TESTING:START -->
+	<!-- test_dot_ext_application_registration -->
+	<!-- CI_TESTING:END -->
 
-<div class="container">
-    <div class="ds-l-row ds-u-justify-content--center ds-u-margin-y--4">
-      <div class="ds-l-lg-col--11 ds-l-md-col--11 ds-l-sm-col--12">
-        <div class="bb-c-card bb-width--75 ds-u-padding--2 bb-raised-section">
-          <form class="form-horizontal" method="post" enctype="multipart/form-data" action="{% block app-form-action-url %}{% url 'oauth2_provider:update' application.id %}{% endblock app-form-action-url %}">
-          {% csrf_token %}
+	<div class="container">
+		<div class="ds-l-row ds-u-justify-content--center ds-u-margin-y--4">
+			<div class="ds-l-lg-col--11 ds-l-md-col--11 ds-l-sm-col--12">
+				<div class="bb-c-card bb-width--75 ds-u-padding--2 bb-raised-section">
+					<form class="form-horizontal" method="post" enctype="multipart/form-data" action="{% block app-form-action-url %}{% url 'oauth2_provider:update' application.id %}{% endblock app-form-action-url %}">
+						{% csrf_token %}
 
-          {% include "include/app-form-required-info.html" %}
-          {% include "include/app-form-optional-info.html" %}
+						{% if form.non_field_errors %}
+						<div class="ds-c-alert ds-c-alert--error ds-u-margin-bottom--2">
+									<div class="ds-c-alert__body">
+										<h3 class="ds-c-alert__heading">Something went wrong.</h3>
+										<ul>
+										{% for error in form.non_field_errors %}
+											<li>{{ error }}</li>
+										{% endfor %}
+										</ul>
+									</div>
+								</div>
+						{% endif %}
 
-          <div>
-              <input type="checkbox" name="agree" id="id_agree" {% if application.name %} checked {% endif %}>
-              <label class="control-label" for="id_agree">Yes I have read and agree to the <a target="_blank" href="https://bluebutton.cms.gov/terms">API Terms of Service Agreement</a>*</label>
-          </div>
+						{% for field in form %}
+							{% for error in field.errors %}
+								<div class="ds-c-alert ds-c-alert--error ds-u-margin-bottom--2">
+									<div class="ds-c-alert__body">
+										<h3 class="ds-c-alert__heading">Something went wrong.</h3>
+										<p class="ds-c-alert__text">{{ error }}</p>
+									</div>
+								</div>
+							{% endfor %}
+						{% endfor %}
 
-          <button type="submit" class="ds-c-button--success ds-u-margin-top--2">Save Application</button>
+						{% include "include/app-form-required-info.html" %}
+						{% include "include/app-form-optional-info.html" %}
 
-        </form>
-      </div>
-    </div>
-  </div>
-</div>
+						<div>
+							<input type="checkbox" name="agree" id="id_agree" {% if application.name %} checked {% endif %}>
+							<label class="control-label" for="id_agree">Yes I have read and agree to the <a target="_blank" href="https://bluebutton.cms.gov/terms">API Terms of Service Agreement</a>*</label>
+						</div>
+
+						<button type="submit" class="ds-c-button--success ds-u-margin-top--2">Save Application</button>
+
+					</form>
+				</div>
+			</div>
+		</div>
+	</div>
 
 {% endblock content %}


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation

<!-- What should reviewers look for to determine completeness -->
For acceptance, I think it should be evident that the defined error messages will show up in the form.

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->
Mostly this: Am I implementing this properly? I removed what appeared to be a duplicated error message from `forms.py` - just want to make sure that's accurate. 

I also think if I had more time to work on this ticket, I would a few extra things. I am curious if we think this is a good idea for a future ticket:

- Update the error messages themselves to be more readable
- Combine the two types of error messages (generated by the two `for` loops) into one alert container, with each error message being an `<li>`.
- Make sections of the errors themselves links to the corresponding field. That way, a user (especially a user with a screen reader/keyboard navigation) could easily jump from the error message to the field that generated the error. I don't think that would be too terribly difficult.

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-xxx](https://jira.cms.gov/browse/BLUEBUTTON-1334)

**Note: this only fixes half of the 1334 ticket.** The sandbox login/registration error messages are still on this legacy bootstrap thing we can't change the HTML for, so that fix will be a separate PR in the CSS repo.

### Security Implications

<!-- Does the change deal with PII/PHI at all? What should reviewers look for in
terms of security concerns? -->

This doesn't have any security implications that I am aware of. It is essentially displaying errors we used to display, but now in the updated Sandbox UI.

