### PR TITLE
Removes forEach for IE compatibility and speed

### DIFF
--- a/static/js/sandbox-main.js
+++ b/static/js/sandbox-main.js
@@ -68,22 +68,22 @@ function toggleCredentials() {
   }
 }
 
-// Toggle on Mouse Click
-appCredentialToggleLinks.forEach(function(appCredentialToggleLink) {
-  appCredentialToggleLink.addEventListener('click', toggleCredentials);
-});
+// Toggle credentials on mouse click
+for (var i = 0; i < appCredentialToggleLinks.length; i++) {
+	appCredentialToggleLinks[i].addEventListener('click', toggleCredentials);
+}
 
-// Toggle for Keyboard Naviagation
-appCredentialToggleLinks.forEach(function(appCredentialToggleLink) {
-  appCredentialToggleLink.addEventListener('keypress', function (e) {
-	  var key = e.which || e.keyCode;
+// Toggle credentials on keyboard navigation
+for (var i = 0; i < appCredentialToggleLinks.length; i++) {
+	appCredentialToggleLinks[i].addEventListener('keypress', function (e) {
+		var key = e.which || e.keyCode;
 	  // If keypress is enter or spacebar
 	  if (key === 13 | key === 32) {
 		  e.preventDefault();
 		  this.click();
 		}
 	});
-});
+}
 
 // Copy Credentials to Clipboard (Run via HTML onClick)
 function copyCredential(copyID) {
@@ -127,30 +127,17 @@ function accordionToggle () {
 }
 
 // Toggle Accordion on Click
-accordions.forEach(function(accordion) {
-	accordion.addEventListener('click', accordionToggle);
-});
+for (var i = 0; i < accordions.length; i++) {
+	accordions[i].addEventListener('click', accordionToggle);
+}
 
 // Toggle Accodrion on Enter Keypress (treated as click)
-accordions.forEach(function(accordion) {
-  accordion.addEventListener('keypress', function(e) {
-    var key = e.which || e.keyCode;
+for (var i = 0; i < accordions.length; i++) {
+	accordions[i].addEventListener('keypress', function (e) {
+		var key = e.which || e.keyCode;
     if (key === 13 | key === 32) {
 		e.preventDefault();
       this.click();
-    }    
-  });
-});
-
-// BB Custom File Input Label Component
-// ------------------------------------
-// Used in the application edit/registration form
-
-const uploadLogoButton = document.querySelector('.bb-c-custom-file-input-label');
-
-uploadLogoButton.addEventListener('change', function(e) {
-  let filePathArray = e.target.value.split("\\").pop();
-  let labelUpdateWithFile = document.querySelector('.upload-file-text');
-
-  labelUpdateWithFile.innerHTML = filePathArray;
-});
+    } 
+	});
+}


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->
While smoke testing the sandbox on dev, I encountered an IE bug that I had missed. Apparently IE 11 doesn't support `forEach`, which I used for the credentials toggle functionality as well as the accordion functionality.

### Acceptance Validation
I tested to make sure the functionality still works and it looks good, so I am really just looking for confirmation of the plan / consistent implementation.
<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### External References

No Jira ticket for this, just a bug I found while smoke testing.

### Security Implications

No security implications with this fix.

