### PR TITLE
BLUEBUTTON-1665 Remove SLS uuid truncation

### DIFF
--- a/apps/dot_ext/tests/test_authentication.py
+++ b/apps/dot_ext/tests/test_authentication.py
@@ -47,7 +47,7 @@ class TestOAuth2Authentication(TestCase):
     def setUp(self):
 
         self.test_username = "0123456789abcdefghijklmnopqrstuvwxyz"
-        self.test_user = UserModel.objects.create_user("9abcdefghijklmnopqrstuvwxyz", "test@example.com", "123456")
+        self.test_user = UserModel.objects.create_user("0123456789abcdefghijklmnopqrstuvwxyz", "test@example.com", "123456")
         self.dev_user = UserModel.objects.create_user("dev_user", "dev@example.com", "123456")
 
         self.application = Application.objects.create(

--- a/apps/dot_ext/tests/test_views.py
+++ b/apps/dot_ext/tests/test_views.py
@@ -78,7 +78,7 @@ class TestAuthorizationView(BaseApiTest):
 
 class TestTokenView(BaseApiTest):
     test_uuid = "0123456789abcdefghijklmnopqrstuvwxyz"
-    test_username = "9abcdefghijklmnopqrstuvwxyz"
+    test_username = "0123456789abcdefghijklmnopqrstuvwxyz"
 
     def _create_test_token(self, user, application):
         # user logs in

--- a/apps/fhir/authentication.py
+++ b/apps/fhir/authentication.py
@@ -22,4 +22,6 @@ def extract_username(auth, auth_prefix="SLS"):
 
 
 def convert_sls_uuid(id):
-    return id[9:36]
+    # Do not shorten SLS guid. It causes username collisions
+    # return id[9:36]
+    return id


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

Stop truncating SLS GUID when creating a user record. This creates the risk for user collisions.

### Acceptance Validation

UserName in User Model and in linked tables reflects the full GUID returned from SLS.

### Feedback Requested

@dtisza1: Is any additional logging required?
### External References

- [BLUEBUTTON-1665](https://jira.cms.gov/browse/BLUEBUTTON-1665)

### Security Implications

If User name collisions occur there is a risk of different FHIR records being returned to a user.
Ensuring a Unique GUID from SLS will eliminate that risk.

- [ ] new software dependencies

N/A

- [ ] altered security controls

N/A

- [ ] new data stored or transmitted

GUID is no longer truncated. Previously the guid was shortened to id[9:36]

- [ ] security checklist is completed for this change

- [ ] requires more information or team discussion to evaluate security implications. Review is essential!

We do not for see any impact to security. This eliminates the risk of PHI/PII Leakage.

