### PR TITLE
BLUEBUTTON-1728 Crosswalk ADMIN search 500-error

### DIFF
--- a/apps/fhir/bluebutton/admin.py
+++ b/apps/fhir/bluebutton/admin.py
@@ -3,8 +3,8 @@ from django.contrib import admin
 
 
 class CrosswalkAdmin(admin.ModelAdmin):
-    list_display = ('get_user_username', 'fhir_id', 'get_fhir_source')
-    search_fields = ('user__username', 'fhir_id', 'fhir_source__name')
+    list_display = ('get_user_username', '_fhir_id', 'get_fhir_source')
+    search_fields = ('user__username', '_fhir_id', 'fhir_source__name')
     raw_id_fields = ("user", )
 
     def get_user_username(self, obj):

--- a/apps/fhir/bluebutton/admin.py
+++ b/apps/fhir/bluebutton/admin.py
@@ -3,7 +3,7 @@ from django.contrib import admin
 
 
 class CrosswalkAdmin(admin.ModelAdmin):
-    list_display = ('get_user_username', '_fhir_id', 'get_fhir_source')
+    list_display = ('get_user_username', 'fhir_id', 'get_fhir_source')
     search_fields = ('user__username', '_fhir_id', 'fhir_source__name')
     raw_id_fields = ("user", )
 


### PR DESCRIPTION
### Change Details

This fixes a bug in the Crosswalk Django Admin where a search produces a 500-error.

One of the search fields was change from `fhir_id` to the use the internal `_fhir_id` to resolve.

### Acceptance Validation
That a search in the Crosswalk Admin produces the expected results and does not error.
### Feedback Requested

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-1728](https://jira.cms.gov/browse/BLUEBUTTON-1728)

### Security Implications

