### PR TITLE
BLUEBUTTON-1563 Claim type parameter in Front-end doesn't handle multiple types

### DIFF
--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -61,7 +61,7 @@ class SearchView(FhirDataView):
         Required('startIndex', default=0): Coerce(int),
         Required('_count', default=DEFAULT_PAGE_SIZE): All(Coerce(int), Range(min=0, max=MAX_PAGE_SIZE)),
         'type': Match(regex_type_values_list, msg="the type parameter value is not valid"),
-        '_lastUpdated': [Match(regex_lastupdated_value, msg="the _lastUpdated operator is not valid")],
+        '_lastUpdated': [Match(regex_lastupdated_value, msg="the _lastUpdated operator is not valid")]
     }
 
     def build_parameters(self, request, *args, **kwargs):


### PR DESCRIPTION
<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details

The `query_schema` in the `SearchView()` class was updated to handle a comma separated list of values for the claim-type parameter. This is used for filtering the resource parameters using the Voluptuous data validation library.

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation

That the claim type parameter can handle multiple comma separated values.  For example, `type=snf,https://bluebutton.cms.gov/resources/codesystem/eob-type|pde,hospice`
<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-1563](https://jira.cms.gov/browse/BLUEBUTTON-1563)

### Security Implications
