### PR TITLE
BLUEBUTTON-1860 Allow list the _lastUpdated parameter for FHIR resource requests

### DIFF
--- a/apps/fhir/bluebutton/tests/test_read.py
+++ b/apps/fhir/bluebutton/tests/test_read.py
@@ -441,6 +441,98 @@ class BackendConnectionTest(BaseApiTest):
 
             self.assertEqual(response.status_code, 502)
 
+    def test_search_parameters_request(self):
+        # create the user
+        first_access_token = self.create_token('John', 'Smith')
+
+        @all_requests
+        def catchall(url, req):
+            self.assertIn("https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/ExplanationOfBenefit/", req.url)
+            self.assertIn("_format=application%2Fjson%2Bfhir", req.url)
+
+            return {
+                'status_code': 200,
+                'content': {
+                    'resourceType': 'ExplanationOfBenefit',
+                    'patient': {
+                        'reference': 'stuff/-20140000008325',
+                    },
+                },
+            }
+
+        # Test _lastUpdated with valid parameter starting with "lt"
+        with HTTMock(catchall):
+            response = self.client.get(
+                reverse(
+                    'bb_oauth_fhir_search',
+                    kwargs={'resource_type': 'ExplanationOfBenefit'}),
+                {'_lastUpdated': 'lt2019-11-22T14:00:00-05:00'},
+                Authorization="Bearer %s" % (first_access_token))
+            self.assertEqual(response.status_code, 200)
+
+        # Test _lastUpdated with invalid parameter starting with "zz"
+        with HTTMock(catchall):
+            response = self.client.get(
+                reverse(
+                    'bb_oauth_fhir_search',
+                    kwargs={'resource_type': 'ExplanationOfBenefit'}),
+                {'_lastUpdated': 'zz2020-11-22T14:00:00-05:00'},
+                Authorization="Bearer %s" % (first_access_token))
+
+            content = json.loads(response.content.decode("utf-8"))
+            self.assertEqual(content['detail'], 'the _lastUpdated operator is not valid')
+            self.assertEqual(response.status_code, 400)
+
+        # Test type= with single valid value: "pde"
+        with HTTMock(catchall):
+            response = self.client.get(
+                reverse(
+                    'bb_oauth_fhir_search',
+                    kwargs={'resource_type': 'ExplanationOfBenefit'}),
+                {'type': 'pde'},
+                Authorization="Bearer %s" % (first_access_token))
+            self.assertEqual(response.status_code, 200)
+
+        # Test type= with multiple (all valid values)
+        with HTTMock(catchall):
+            response = self.client.get(
+                reverse(
+                    'bb_oauth_fhir_search',
+                    kwargs={'resource_type': 'ExplanationOfBenefit'}),
+                {'type': 'carrier,'
+                         'pde,'
+                         'dme,'
+                         'hha,'
+                         'hospice,'
+                         'inpatient,'
+                         'outpatient,'
+                         'snf,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|carrier,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|pde,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|dme,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|hha,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|hospice,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|inpatient,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|outpatient,'
+                         'https://bluebutton.cms.gov/resources/codesystem/eob-type|snf'},
+                Authorization="Bearer %s" % (first_access_token))
+            self.assertEqual(response.status_code, 200)
+
+        # Test type= with an invalid type
+        with HTTMock(catchall):
+            response = self.client.get(
+                reverse(
+                    'bb_oauth_fhir_search',
+                    kwargs={'resource_type': 'ExplanationOfBenefit'}),
+                {'type': 'carrier,'
+                         'INVALID-TYPE,'
+                         'dme,'},
+                Authorization="Bearer %s" % (first_access_token))
+
+            content = json.loads(response.content.decode("utf-8"))
+            self.assertEqual(content['detail'], 'the type parameter value is not valid')
+            self.assertEqual(response.status_code, 400)
+
     def test_read_request_failed_no_fhir_id(self):
         # create the user
         first_access_token = self.create_token('John', 'Smith')

--- a/apps/fhir/bluebutton/views/generic.py
+++ b/apps/fhir/bluebutton/views/generic.py
@@ -51,6 +51,9 @@ class FhirDataView(APIView):
 
     def filter_parameters(self, request):
         params = self.map_parameters(request.query_params.dict())
+        # Get list from _lastUpdated QueryDict(), since it can have multi params
+        params['_lastUpdated'] = request.query_params.getlist('_lastUpdated')
+
         schema = voluptuous.Schema(
             getattr(self, "query_schema", {}),
             extra=voluptuous.REMOVE_EXTRA)

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -30,7 +30,6 @@ class SearchView(FhirDataView):
     # Regex to match a valid type value
     regex_type_value = r"(carrier)|" + \
         r"(pde)|" + \
-        r"(https://bluebutton.cms.gov/resources/codesystem/eob-type\|pde)" + \
         r"(dme)|" + \
         r"(hha)|" + \
         r"(hospice)|" + \


### PR DESCRIPTION
### Change Details

This adds `_lastUpdated` to the allowed list of parameters for FHIR resource requests.

There is more information about this parameter here:  https://github.com/CMSgov/beneficiary-fhir-data/blob/d3da960f238f26e66702fd7f13cc87d67583a3da/rfcs/0004-since-parameter.md


<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation

That the `_lastUpdaed` parameter is validated and included in the request to the BFD. It will also handle multiple parameters to produced a data/time search range.

<!-- What should reviewers look for to determine completeness -->

<!-- Insert screenshots if applicable (drag images here) -->

### Feedback Requested

<!-- What type of feedback you want from your reviewers? -->

### External References

<!-- For example: replace xxx with the JIRA ticket number: -->

- [BLUEBUTTON-1860](https://jira.cms.gov/browse/BLUEBUTTON-1860)

### Security Implications
