### PR TITLE
Correct admin url prepend conf

### DIFF
--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -438,7 +438,8 @@ LOGIN_URL = '/v1/accounts/login'
 
 LOGOUT_REDIRECT_URL = '/'
 
-# Move Admin to a variable url location ADMIN_PREPEND_URL = env('DJANGO_ADMIN_PREPEND_URL', '')
+# Move Admin to a variable url location
+ADMIN_PREPEND_URL = env('DJANGO_ADMIN_PREPEND_URL', '')
 
 ALLOW_END_USER_EXTERNAL_AUTH = "B"
 EXTERNAL_AUTH_NAME = 'MyMedicare.gov'


### PR DESCRIPTION

<!--

--- PR Hygiene Checklist ---

1. Make sure the changeset can be reviewed, keep it's scope and size succinct 
2. Make sure your branch is from your fork and has a meaningful name
3. Update the PR title: `BLUEBUTTON-99999 Add Awesomeness`
4. Edit the text below - do not leave placeholders in the text.
4.1. Remove sections that you don't feel apply
5. Add any other details that will be helpful for the reviewers: details description, screenshots, etc
6. Request a review from someone/multiple someones
7. <optional> Review your changes yourself and write up any comments / concerns as if you were reviewing someone else's code.
-->

### Change Details
The configuration for prepending a string to the admin url was unintentionally removed by a typo, this adds it back in.

<!-- Add detailed discussion of changes here: -->
<!-- This is likely a summary, or the complete contents, of your commit messages -->

### Acceptance Validation
The typo is corrected.

### External links:
https://github.com/whytheplatypus/bluebutton-web-server/blob/55e6f2106f4d84dd457de8cff1e4a24685924015/hhs_oauth_server/settings/base.py#L441