### PR TITLE
BB2-126 Update MSLS container to include MBI for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,4 @@ ADD . /code/
 WORKDIR /code
 RUN make reqs-install-dev
 RUN pip install pip-tools
-RUN pip install psycopg2
+RUN pip install psycopg2-binary

--- a/apps/accounts/models.py
+++ b/apps/accounts/models.py
@@ -246,7 +246,7 @@ class UserIdentificationLabel(models.Model):
     slug = models.SlugField(db_index=True, unique=True)
     weight = models.IntegerField(verbose_name="List Weight", null=False, default=0,
                                  help_text="Integer value controlling the position of the label in lists.")
-    users = models.ManyToManyField(settings.AUTH_USER_MODEL, null=True, blank=True)
+    users = models.ManyToManyField(settings.AUTH_USER_MODEL, blank=True)
 
     def __str__(self):
         return self.slug + " - " + self.name

--- a/apps/dot_ext/models.py
+++ b/apps/dot_ext/models.py
@@ -129,7 +129,7 @@ class ApplicationLabel(models.Model):
     name = models.CharField(max_length=255, unique=True)
     slug = models.SlugField(db_index=True, unique=True)
     description = models.TextField()
-    applications = models.ManyToManyField(Application, null=True, blank=True)
+    applications = models.ManyToManyField(Application, blank=True)
 
     @property
     def short_description(self):

--- a/apps/fhir/bluebutton/models.py
+++ b/apps/fhir/bluebutton/models.py
@@ -107,7 +107,6 @@ class Crosswalk(models.Model):
             raise ValidationError("this value cannot be modified.")
         self.user_id_hash = hash_pt_identity(hicn)
 
-
     def get_fhir_resource_url(self, resource_type):
         # Return the fhir server url
         full_url = self.fhir_source.fhir_url

--- a/apps/fhir/bluebutton/models.py
+++ b/apps/fhir/bluebutton/models.py
@@ -25,15 +25,16 @@ class SynthCrosswalkManager(models.Manager):
         return super().get_queryset().filter(Q(_fhir_id__startswith='-'))
 
 
-def hash_hicn(hicn):
+# def hash_hicn(hicn):
+def hash_pt_identity(pt_identity):
     """
     Hashes a hicn to match fhir server logic:
     https://github.com/CMSgov/beneficiary-fhir-data/blob/master/apps/bfd-pipeline/bfd-pipeline-rif-load/src/main/java/gov/cms/bfd/pipeline/rif/load/RifLoader.java#L665-L706
 
     """
-    assert hicn != "", "HICN cannot be the empty string"
+    assert pt_identity != "", "patient identity cannot be the empty string"
 
-    return binascii.hexlify(pbkdf2(hicn,
+    return binascii.hexlify(pbkdf2(pt_identity,
                             get_user_id_salt(),
                             settings.USER_ID_ITERATIONS)).decode("ascii")
 
@@ -104,7 +105,8 @@ class Crosswalk(models.Model):
     def set_hicn(self, hicn):
         if self.pk:
             raise ValidationError("this value cannot be modified.")
-        self.user_id_hash = hash_hicn(hicn)
+        self.user_id_hash = hash_pt_identity(hicn)
+
 
     def get_fhir_resource_url(self, resource_type):
         # Return the fhir server url

--- a/apps/fhir/bluebutton/utils.py
+++ b/apps/fhir/bluebutton/utils.py
@@ -137,6 +137,8 @@ def generate_info_headers(request):
         # we need to send the HicnHash or the fhir_id
         if crosswalk.fhir_id is not None:
             result['BlueButton-BeneficiaryId'] = 'patientId:' + str(crosswalk.fhir_id)
+        elif crosswalk.user_id_type == 'M':
+            result['BlueButton-BeneficiaryId'] = 'mbiHash:' + str(crosswalk.user_mbi_hash)
         else:
             result['BlueButton-BeneficiaryId'] = 'hicnHash:' + str(crosswalk.user_id_hash)
     else:

--- a/apps/fhir/server/authentication.py
+++ b/apps/fhir/server/authentication.py
@@ -9,16 +9,13 @@ from ..bluebutton.utils import (FhirServerAuth,
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
-# FHIR_PAT_ID_SYS_URI = "https://bluebutton.cms.gov/resources/identifier/"
-# FHIR_PAT_ID_SEARCH_PARAM_HICN = "hicn-hash"
-# FHIR_PAT_ID_SEARCH_PARAM_MBI = "mbi-hash"
 FHIR_URL_FORMATTER = "{}Patient/?{}|{}&_format=application/json+fhir"
+
 
 def match_pt_id_hash(id_hash, id_type):
     auth_state = FhirServerAuth(None)
     certs = (auth_state['cert_file'], auth_state['key_file'])
     # URL for patient ID.
-    id_hash_type = settings.FHIR_PAT_ID_SEARCH_PARAM_MBI
     if id_type == 'H':
         id_param_type = settings.FHIR_PAT_ID_SEARCH_PARAM_HICN
     elif id_type == 'M':
@@ -27,7 +24,8 @@ def match_pt_id_hash(id_hash, id_type):
         id_param_type = settings.FHIR_PAT_ID_SEARCH_PARAM_BEN
 
     sys_uri = settings.FHIR_PAT_ID_SYS_URI + id_param_type
-    url = FHIR_URL_FORMATTER.format(get_resourcerouter().fhir_url, urllib.parse.urlencode({'identifier': sys_uri}, doseq=True), id_hash)
+    url = FHIR_URL_FORMATTER.format(get_resourcerouter().fhir_url, 
+        urllib.parse.urlencode({'identifier': sys_uri}, doseq=True), id_hash)
     response = requests.get(url, cert=certs, verify=False)
     response.raise_for_status()
     backend_data = response.json()

--- a/apps/fhir/server/authentication.py
+++ b/apps/fhir/server/authentication.py
@@ -24,8 +24,8 @@ def match_pt_id_hash(id_hash, id_type):
         id_param_type = settings.FHIR_PAT_ID_SEARCH_PARAM_BEN
 
     sys_uri = settings.FHIR_PAT_ID_SYS_URI + id_param_type
-    url = FHIR_URL_FORMATTER.format(get_resourcerouter().fhir_url, 
-        urllib.parse.urlencode({'identifier': sys_uri}, doseq=True), id_hash)
+    url = FHIR_URL_FORMATTER.format(get_resourcerouter().fhir_url,
+                                    urllib.parse.urlencode({'identifier': sys_uri}, doseq=True), id_hash)
     response = requests.get(url, cert=certs, verify=False)
     response.raise_for_status()
     backend_data = response.json()

--- a/apps/fhir/server/tests/test_authentication.py
+++ b/apps/fhir/server/tests/test_authentication.py
@@ -3,7 +3,7 @@ from rest_framework import exceptions
 from requests.exceptions import HTTPError
 from apps.fhir.bluebutton.exceptions import UpstreamServerException
 from httmock import all_requests, HTTMock
-from ..authentication import match_hicn_hash
+from ..authentication import match_pt_id_hash
 from .responses import responses
 
 
@@ -14,7 +14,7 @@ class TestAuthentication(TestCase):
         def fhir_mock(url, request):
             return responses['success']
         with HTTMock(fhir_mock):
-            fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+            fhir_id, backend_data = match_pt_id_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b", 'H')
             self.assertEqual(backend_data, responses['success']['content'])
             self.assertEqual(fhir_id, "-20000000002346")
 
@@ -24,7 +24,7 @@ class TestAuthentication(TestCase):
             return responses['not_found']
         with HTTMock(fhir_mock):
             with self.assertRaises(exceptions.NotFound):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, backend_data = match_pt_id_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b", 'H')
 
     def test_match_hicn_hash_server_error(self):
         @all_requests
@@ -32,7 +32,7 @@ class TestAuthentication(TestCase):
             return responses['error']
         with HTTMock(fhir_mock):
             with self.assertRaises(HTTPError):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, backend_data = match_pt_id_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b", 'H')
 
     def test_match_hicn_hash_duplicates(self):
         @all_requests
@@ -40,7 +40,7 @@ class TestAuthentication(TestCase):
             return responses['duplicates']
         with HTTMock(fhir_mock):
             with self.assertRaises(UpstreamServerException):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, backend_data = match_pt_id_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b", 'H')
 
     def test_match_hicn_hash_malformed(self):
         @all_requests
@@ -48,7 +48,7 @@ class TestAuthentication(TestCase):
             return responses['malformed']
         with HTTMock(fhir_mock):
             with self.assertRaises(KeyError):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, backend_data = match_pt_id_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b", 'H')
 
     def test_match_hicn_hash_lying_duplicates(self):
         @all_requests
@@ -56,4 +56,4 @@ class TestAuthentication(TestCase):
             return responses['lying']
         with HTTMock(fhir_mock):
             with self.assertRaises(UpstreamServerException):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, backend_data = match_pt_id_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b", 'H')

--- a/apps/mymedicare_cb/models.py
+++ b/apps/mymedicare_cb/models.py
@@ -35,7 +35,6 @@ def get_and_update_user(user_info):
         pt_identity = hash_pt_identity(pt_identity)
 
     # raises exceptions.NotFound:
-    #fhir_id, backend_data = match_hicn_hash(hicn_hash)
     fhir_id, backend_data = match_pt_id_hash(pt_identity, id_type)
 
     try:

--- a/apps/mymedicare_cb/tests/test_callback.py
+++ b/apps/mymedicare_cb/tests/test_callback.py
@@ -161,6 +161,8 @@ class MyMedicareBlueButtonClientApiUserInfoTest(TestCase):
                     'given_name': '',
                     'family_name': '',
                     'email': 'bob@bobserver.bob',
+                    'identity_type': 'H',
+                    'pt_identity': '1234567890A', 
                     'hicn': '1234567890A',
                 },
             }

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -76,6 +76,7 @@ def authenticate(request):
             "crosswalk": {
                 "id": user.crosswalk.id,
                 "user_id_hash": user.crosswalk.user_id_hash,
+                "user_id_type": user.crosswalk.user_id_type,
                 "fhir_id": user.crosswalk.fhir_id,
             },
         },

--- a/apps/testclient/management/commands/create_test_user_and_application.py
+++ b/apps/testclient/management/commands/create_test_user_and_application.py
@@ -79,12 +79,12 @@ def create_user(group):
     return u, u2
 
 
-def create_application(user, group):
-    Application.objects.filter(name="TestApp").delete()
+def create_application(user, group, appName):
+    Application.objects.filter(name=appName).delete()
     redirect_uri = "%s/testclient/callback" % (settings.HOSTNAME_URL)
     if not(redirect_uri.startswith("http://") or redirect_uri.startswith("https://")):
         redirect_uri = "https://" + redirect_uri
-    a = Application.objects.create(name="TestApp",
+    a = Application.objects.create(name=appName,
                                    redirect_uris=redirect_uri,
                                    user=user,
                                    client_type="confidential",
@@ -102,7 +102,7 @@ def create_application(user, group):
     return a
 
 
-def create_test_token(user, application):
+def create_test_token(user, application, tk):
 
     now = timezone.now()
     expires = now + timedelta(days=1)
@@ -113,7 +113,7 @@ def create_test_token(user, application):
         scope.append(s.slug)
 
     t = AccessToken.objects.create(user=user, application=application,
-                                   token="sample-token-string",
+                                   token=tk,
                                    expires=expires,
                                    scope=' '.join(scope))
     return t
@@ -125,10 +125,10 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         g = create_group()
         u, u2 = create_user(g)
-        a = create_application(u, g)
-        a2 = create_application(u2, g)
-        t = create_test_token(u, a)
-        t2 = create_test_token(u2, a2)
+        a = create_application(u, g, "TestApp")
+        a2 = create_application(u2, g, "TestApp2")
+        t = create_test_token(u, a, "sample-token-string")
+        t2 = create_test_token(u2, a2, "sample-token-string2")
         update_grants()
         print("------------ sample user #1 : fred ------------")
         print("Name:", a.name)

--- a/apps/testclient/management/commands/create_test_user_and_application.py
+++ b/apps/testclient/management/commands/create_test_user_and_application.py
@@ -51,15 +51,16 @@ def create_user(group):
 
     u.groups.add(group)
     c, g_o_c = Crosswalk.objects.get_or_create(user=u,
-                                                user_id_type='M',
-                                                _fhir_id=settings.DEFAULT_SAMPLE_FHIR_ID,
-                                                _user_id_hash="0b2b0f53d207a7b5867e834277490fdacf2642fafb51fe40030cc890a73a188f")
+                                               user_id_type='M',
+                                               _fhir_id=settings.DEFAULT_SAMPLE_FHIR_ID,
+                                               _user_id_hash="0b2b0f53d207a7b5867e834277490fdacf2642fafb51fe40030cc890a73a188f")
 
     u2 = User.objects.create_user(username="jane",
-                                 first_name="Jane",
-                                 last_name="Doe",
-                                 email='jane@example.com',
-                                 password="foobarfoobarfoobar",)
+                                  first_name="Jane",
+                                  last_name="Doe",
+                                  email='jane@example.com',
+                                  password="foobarfoobarfoobar",)
+
     UserProfile.objects.create(user=u2,
                                user_type="BEN",
                                create_applications=True,
@@ -72,9 +73,9 @@ def create_user(group):
 
     u2.groups.add(group)
     c1, g_o_c1 = Crosswalk.objects.get_or_create(user=u2,
-                                                user_id_type='H',
-                                                _fhir_id=settings.DEFAULT_SAMPLE_FHIR_ID_HICN,
-                                                _user_id_hash="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7")
+                                                 user_id_type='H',
+                                                 _fhir_id=settings.DEFAULT_SAMPLE_FHIR_ID_HICN,
+                                                 _user_id_hash="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7")
     return u, u2
 
 

--- a/dev-local/.env.example
+++ b/dev-local/.env.example
@@ -1,0 +1,8 @@
+## For Windows
+COMPOSE_CONVERT_WINDOWS_PATHS=1
+BFD_DIR=../../beneficiary-fhir-data
+BB20_CONTEXT=../../bluebutton-web-server
+SYNTHETIC_DATA=./synthetic-data
+CERTSTORE=./certstore
+## enable ptvsd remote debugging on port 5678
+BB20_ENABLE_REMOTE_DEBUG=true

--- a/dev-local/Dockerfile
+++ b/dev-local/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu:18.04
+COPY . /config
+RUN apt-get update
+RUN apt install -y maven openjdk-8-jdk make
+RUN useradd -ms /bin/bash dev
+USER dev
+RUN mkdir -p $HOME/.m2
+RUN cp /config/toolchains.xml $HOME/.m2/toolchains.xml
+RUN ls $HOME/.m2
+RUN cat $HOME/.m2/toolchains.xml

--- a/dev-local/Makefile
+++ b/dev-local/Makefile
@@ -1,0 +1,23 @@
+BFD_MOUNT_POINT ?= "beneficiary-fhir-data"
+# psword for certs: changeit
+build:
+	cd ${BFD_MOUNT_POINT}/apps; mvn -Dmin_port=9954 -Dmax_port=9954 clean install -DskipITs
+
+verify:
+	cd ${BFD_MOUNT_POINT}/apps; mvn clean verify
+
+run: build
+	cd ${BFD_MOUNT_POINT}/apps/bfd-server; mvn --projects bfd-server-war package dependency:copy antrun:run org.codehaus.mojo:exec-maven-plugin:exec@server-start
+
+docker: build
+	cd ${BFD_MOUNT_POINT}/apps/bfd-server; mvn -Dits.db.url="jdbc:postgresql://bfddb:5432/bfd?user=bfd&password=InsecureLocalDev" --projects bfd-server-war package dependency:copy antrun:run org.codehaus.mojo:exec-maven-plugin:exec@server-start
+	tail -f ${BFD_MOUNT_POINT}/apps/bfd-server/bfd-server-war/target/server-work/server-console.log
+
+stop:
+	cd ${BFD_MOUNT_POINT}/apps/bfd-server; mvn --projects bfd-server-war package dependency:copy antrun:run org.codehaus.mojo:exec-maven-plugin:exec@server-stop
+
+fix: build
+	cd ${BFD_MOUNT_POINT}/apps/bfd-pipeline/bfd-pipeline-rif-extract; mvn exec:java -Dexec.mainClass="gov.cms.bfd.pipeline.rif.extract.synthetic.SyntheticDataFixer4" -Dexec.classpathScope=test
+
+load: 
+	cd ${BFD_MOUNT_POINT}/apps/bfd-pipeline/bfd-pipeline-rif-load; mvn -Dits.db.url=jdbc:postgresql://bfddb:5432/bfd -Dits.db.username=bfd -Dits.db.password=InsecureLocalDev -Dit.test=RifLoaderIT#loadSyntheticData clean verify

--- a/dev-local/README.md
+++ b/dev-local/README.md
@@ -1,0 +1,103 @@
+# Docker Compose
+
+## BFD
+The bfd system needs a few variables to be set:
+- `BFD_DIR` specifies the directory on your host machine where you have cloned https://github.com/CMSgov/beneficiary-fhir-data
+- (optional) `SYNTHETIC_DATA` specifies a folder where you have the full set of synthetic rif files.
+- (defaults to `/app`) `BFD_MOUNT_POINT` the path within the service container where the beneficiary-fhir-data directory will be mounted.
+
+Here's an example `.env` file that docker-compose could use:
+
+```
+BFD_DIR=../../beneficiary-fhir-data
+BB20_CONTEXT=../../bb2_dev_local_B
+SYNTHETIC_DATA=./synthetic-data
+CERTSTORE=./certstore
+BB20_ENABLE_REMOTE_DEBUG=true
+
+```
+the .env assume a source tree topology as below:
+<cms_projects_base_dir>/bluebutton-web-server
+<cms_projects_base_dir>/beneficiary-fhir-data
+
+run following commands to build container and start up instances:
+
+```
+docker-compose up -d bfd
+docker-compose logs -f | grep bfd_1
+docker-compose exec bfd make load
+```
+then build and start up down stream blue button server:
+
+## bb 2.0 specific
+```
+docker-compose up -d bb20
+docker-compose logs -f | grep bb20
+docker-compose exec bb20 ./docker-compose/migrate.sh
+```
+
+## To work on Windows, a linux sub system is required:
+## Tetsted with Cygwin, WSL, VirtualBox + Linux
+## For Docker server, please install Docker Desktop on host (Windows)
+## and set DOCKER_HOST environment variable in linux sub system
+## On Windows, take care of EOL CRLF/LF by 
+
+```
+git config --global core.autocrlf true
+```
+and in .env add below hint:
+COMPOSE_CONVERT_WINDOWS_PATHS=1
+
+
+## Test and verification
+
+After containers are up and running, go to localhost:8000 (default) and you will see CMS Blue Button landing page,
+follow documentation to create account, register applications, etc., note, on a local development environment, email might not be properly set, so confirmation email might not be received, and hence account activation needs to
+be done manually by going to localhost:8000/admin and activate it.
+
+Test from clients:
+
+
+* Test from in browser testclient - from top of developer sandbox click link 'testclient'
+* Test from CMS Blue Button Sample Clients:
+  * Ruby on Rails Sample Client: [Blue Button Sample Client Rails](https://github.com/CMSgov/bluebutton-sample-client-rails) 
+  * Django Sample Client: [Blue Button Sample Client Django](https://github.com/CMSgov/bluebutton-sample-client-django)
+
+Make changes to configurations following sample clients instructions and test the end to end scenarios.
+
+## Remote debugging blue button server
+## add to .env below environment variable for bb20 container
+
+BB20_ENABLE_REMOTE_DEBUG=true
+
+## Start blue button server
+
+```
+cd <cms_projects_base_dir>/bluebutton-web-server/dev-local
+docker-compose up -d bb20
+
+```
+## After bb20 is up and running, ptvsd is listening on port 5678,
+## attach to bb20 from IDE, e.g. VSCode and put break points on execution path, and debugging.
+
+
+## Remote debugging blue button server unit tests
+
+```
+cd <cms_projects_base_dir>/bluebutton-web-server/dev-local
+docker-compose up -d bb20tests
+
+```
+## docker-compose up -d bb20tests starts with ptvsd wait on port 6789 for debugger to attach,
+## attach to bb20tests from IDE, e.g. VSCode and put break points in test cases, and debugging.
+
+```
+docker-compose up -d bb20tests
+
+```
+make sure tests are waiting on 6789:
+
+.....................
+dev-local_bb20tests_1   python3 -m ptvsd --host 0. ...   Up      0.0.0.0:6789->6789/tcp
+
+

--- a/dev-local/docker-compose.yml
+++ b/dev-local/docker-compose.yml
@@ -1,0 +1,97 @@
+version: '3.3'
+
+services:
+
+  bfddb:
+    image: postgres:9.6
+    environment:
+      POSTGRES_DB: bfd
+      POSTGRES_USER: bfd
+      POSTGRES_PASSWORD: InsecureLocalDev
+    ports:
+      - "5433:5432"
+  bfd:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    user: dev
+    working_dir: /code
+    command: make docker
+    volumes:
+      - .:/code
+      - ${BFD_DIR}:${BFD_MOUNT_POINT:-/app}
+      - ${SYNTHETIC_DATA}:/synthetic-data
+    environment:
+      JAVA_HOME: "/usr/lib/jvm/java-1.8.0-openjdk-amd64/"
+      BFD_PORT: 9954
+      LOCAL_SYNTHETIC_DATA: "/synthetic-data"
+      BFD_MOUNT_POINT: ${BFD_MOUNT_POINT:-/app}
+    ports:
+      - "1337:9954"
+      - "10999:10999"
+    depends_on:
+      - bfddb
+  msls:
+    build:
+      context: ./msls
+      dockerfile: Dockerfile
+    command: msls
+    ports: 
+      - "8080:8080"
+  bbdb:
+    image: postgres
+    environment:
+      - POSTGRES_DB=bluebutton
+      - POSTGRES_PASSWORD=toor
+    ports:
+      - "5432:5432"
+  bb20:
+    build:
+      context: ${BB20_CONTEXT}
+      dockerfile: Dockerfile
+    command: bash -c "if [ ! -d 'bluebutton-css' ] ; then git clone https://github.com/CMSgov/bluebutton-css.git ; else echo 'CSS already installed.' ; fi ; if [ '${BB20_ENABLE_REMOTE_DEBUG}' = true ] ; then python3 -m ptvsd --host 0.0.0.0 --port 5678 manage.py runserver 0.0.0.0:8000 --noreload ; else python3 manage.py runserver 0.0.0.0:8000; fi"
+    environment:
+      - DJANGO_SETTINGS_MODULE=hhs_oauth_server.settings.dev
+      - DATABASES_CUSTOM=postgres://postgres:toor@bbdb:5432/bluebutton
+      - OAUTHLIB_INSECURE_TRANSPORT=true
+      - DJANGO_DEFAULT_SAMPLE_FHIR_ID="-20140000008325"
+      - DJANGO_SECURE_SESSION=False
+      - DJANGO_MEDICARE_LOGIN_URI=http://192.168.0.187:8080?scope=openid%20profile&client_id=bluebutton
+      - DJANGO_SLS_USERINFO_ENDPOINT=http://msls:8080/userinfo
+      - DJANGO_SLS_TOKEN_ENDPOINT=http://msls:8080/token
+      - FHIR_URL=https://bfd.local:9954/v1/fhir/
+      - BB20_ENABLE_REMOTE_DEBUG=${BB20_ENABLE_REMOTE_DEBUG}
+      # - FHIR_URL="https://prod-sbx.bfdcloud.net/v1/fhir/"
+      # - BB20_ENABLE_REMOTE_DEBUG=${BB20_ENABLE_REMOTE_DEBUG}
+    ports:
+      - "8000:8000"
+      - "5678:5678"
+    links:
+      - "bfd:bfd.local"
+    volumes:
+      - ${BB20_CONTEXT}:/code
+      - ./certstore:/certstore
+    depends_on:
+      - bbdb
+      - msls
+  bb20tests:
+    build:
+      context: ${BB20_CONTEXT}
+      dockerfile: Dockerfile
+    command: python3 -m ptvsd --host 0.0.0.0 --port 6789 --wait runtests.py
+    environment:
+      - DJANGO_SETTINGS_MODULE=hhs_oauth_server.settings.dev
+      - DATABASES_CUSTOM=postgres://postgres:toor@bbdb:5432/bluebutton
+      - OAUTHLIB_INSECURE_TRANSPORT=true
+      - DJANGO_DEFAULT_SAMPLE_FHIR_ID="-20140000008325"
+      - DJANGO_SECURE_SESSION=False
+      - DJANGO_MEDICARE_LOGIN_URI=http://127.0.0.1:8080?scope=openid%20profile&client_id=bluebutton
+      - DJANGO_SLS_USERINFO_ENDPOINT=http://msls:8080/userinfo
+      - DJANGO_SLS_TOKEN_ENDPOINT=http://msls:8080/token
+      - FHIR_URL=https://bfd.local:9954/v1/fhir/
+    ports:
+      - "6789:6789"
+    volumes:
+      - ${BB20_CONTEXT}:/code
+      - ./certstore:/certstore
+      

--- a/dev-local/fetch.sh
+++ b/dev-local/fetch.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+wget --directory-prefix synthetic-data \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/0_manifest.xml \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-beneficiary-1999.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-beneficiary-2000.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-beneficiary-2014.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-1999-1999.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-1999-2000.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-1999-2001.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2000-2000.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2000-2001.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2000-2002.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2014-2014.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2014-2015.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-carrier-2014-2016.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-1999-1999.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-1999-2000.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-1999-2001.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2000-2000.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2000-2001.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2000-2002.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2014-2014.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2014-2015.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-inpatient-2014-2016.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-pde-2014.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-pde-2015.rif \
+     https://s3.amazonaws.com/bfd-public-test-data/data-synthetic/2020-1-25-mbi-with-negative-ids/synthetic-pde-2016.rif

--- a/dev-local/msls/Dockerfile
+++ b/dev-local/msls/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:alpine
+FROM golang:1.13.5-alpine3.10
 
 WORKDIR /go/src/app
 COPY . .
 
 RUN go install -v .
 
-CMD ["app"]
+CMD ["msls"]

--- a/dev-local/msls/login_form.go
+++ b/dev-local/msls/login_form.go
@@ -1,12 +1,76 @@
 package main
 
 var login_template = `
-<form method="post" action="/login">
-<input type="text" name="username"></input>
-<input type="text" name="password"></input>
+<style>
+label{
+    display: inline-block;
+    float: left;
+    clear: left;
+    width: 250px;
+    text-align: left; /*Change to right here if you want it close to the inputs*/
+}
+input {
+  display: inline-block;
+  float: left;
+}
+.container {
+  width: 500px;
+  clear: both;
+}
+.container input {
+  width: 100%;
+  clear: both;
+}
+.txtwrapleft {
+  float: left;
+  margin: 10px;
+}
+submit{
+  padding-left: 100px;
+}
+</style>
 
-<input type="hidden" name="state" value="{{ .Get "state" }}"></input>
-<input type="hidden" name="redirect_uri" value="{{ .Get "redirect_uri" }}"></input>
-<button type="submit">Sign In</button>
+<h1>MSLS Component Inputs for simulating SLS/MyMedicare auth flow locally</h1>
+<p>
+<img class="txtwrapleft" alt="BB2 Local Dev Warning" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHwAAAB8CAMAAACcwCSMAAAAnFBMVEX/////1CoAAAD/1iqNjY3cuiX/2iv/2Cv/3Sz/3yzHx8fa2trw8PDr6+seHh719fX20Cmrq6vwyyhra2t8fHwxMTFAQEDBwcHj4+OHchddTQ8lIAa3t7e6nR9IPAwVEAPkwiZLS0s5LwnCpCAPDw9VRw5CNgukiRswKAhVVVVmVhGYmJjR0dGukR3OsCNhYWF8aRRzYBORexgdFwXm0SpPAAAFR0lEQVRoge1a63qiMBBdiCTQ1pbauuulWlfXXmy1Vd//3ZbMBAiQBARC/3D6fS0C5Tgx58xM4q9fPXr06NGjR48fx/XV9Q8x3zy6HIO7H+D+dAXG3Uc/vI3J3d+dx/7opvjomPsaWHf7Lfy96Zb8nXPOAhqs+cFjp9x/IOAVcdgBjiZdksNsm1LHcYIZP/zqkPsewg1JRM48OP7sjhz4Xn2HI/jmL/52xj3gdHMK3A5ZPfOXTx1xTyDwjSB3/FfwuY6c5gskHnM7JFx35zRXELjHYnKHLviJf8MuyH9zqu8k8Ch0tuzKaVBmI5KSd+g0KDMp8A6dBmT2HGS4I7nBW7qyzD0ElkU28Cj0KSR2y+QPnGTr57gdMjrbdxqsnQ4kTx47jdXE/hdkFhS4Y6cZWOR+gtk2KgYeOc0GnMae3G7GCpklsUNF9WCNHGT2FiaBE0Zp8kI4ja06OiczQkNvsVixJLvt+OV3S+Qgs5d4ttFwCon8Ze8T+06D1bInxhlTGWA9YpLTjK2QQzY7BrKuBeY4DcgIhuLeAjfKbCWGeDSXyGMBWHOaO5DZSRgr8WRu99sXTvNix2k+QGaxv5DVWSY/UatOM/kHMoszChm9yeT7WG7MitNgNkvqNjHAMRbxBSstBGYzuWhcyuSb5AI98tftthAoM8nUg61MnuZY4TR/WuQGmWWKxmAnk3vplfadBptSOY37U4k7Vj/OBjjVntOAzJ5DOY1T2eEyGd7fg9zacpphVk5IvpfIz45E3rLTwNrPlmTqF7aRyOeZghKdpqXEjtnskK1fmOyvb9mijkEL0Y7TwNrPLlc7CUkhljny9pwGZbYiBvJdrpylsFjRRgsBpn7KF40Zc5/6+YtwunkLATJzSb5aJqHkr6d8B+Of+Onbptx3CpkhZil54TIJW6lpQGZvhd4s+lwlfy30jbHTNFunETJjRXL/mJIrrrN1c6d5V01mJJ8ayYXTNKlpCms/0tMlc/cUzRvbNXSaO0jjU2VvJpn7OW8CQI5OU7+FgLWfs7IpjccV5qO6bW22LKqXmZMx97WSXDhN3ZpGKzPp2RxLRz024DRuPe6JVmZAHibkW03DzsBp6i2LwhLrViUzJE/aBt09Yk7WqWkMMkPypHJX+gCw13Ya7dpPzJ6Yez6ppeR1ncYkM3xy4jK6aREngIudBjcMX3Ux8cipyOhT/Rsk9ZwG1n5eQv1z+acOcZ2Y4SZaZ1kUs9lGraGEna02hxU1vsE6NQ3IbGbmBnpT2BD65TUNNqWqfJEjJ4X6Kn8HdS91mnGJzBAsGHleGGjnOoaOq1bVaxrFToYC/mEb+efzzjN/OhTMqPIGzE2pzOChp1jnxRJOBrusewKZrY0yy3aKZlVc5DSanYwsMh3L3DjtLqppcms/mnDk/jxdEFLCr+40JdlMIJjJ5NrUAhBOU6WFKGwYqqPJLAgdzarEYargNNVkdlHkkRGeKzkN1k6FprQY+UkmN3/mlZ0GZptrTBYYjDzb3RJZRgO15reVOM11FZlhMNJ0L7+/0gYMFo0VuKPnJQOv2W7KADdgjFu9YsOwEjmhm2Xk7edZpdsr1DTQlB4rcUeg1DscVn7JZBModRr0l/I0nsZTWkykt45KvlQC1XJhgaUl4AaMtnEcwsKTuvFqDuyetDYH003djbcBSK23uubps6pumpDrvtACDjMLGOE/RPot/son8jeJAzwm+SfwAxqaswuUT8eDZwWbtdlmBq516FeDh2Pb3KbU8nlb/v9N8GBMqpMvm9zl1cT9x8AKPp5+4nvJPXr06NGjRw/L+A+1m15/RgPGHAAAAABJRU5ErkJggg==">
+<h2>Simulated Authentication no PHI or PII</h2>
+<h2>Use Only Synthetic Beneficiary Info</h2>
+<h2>Enter values to be returned by the SLS user_info endpoint below:</h2>
+</p>
+<br>
+<br>
+<form method="post" action="/login">
+<div>
+    <h3>Enter User Name:</h3>
+    <label>SUB(username): </label> <input type="text" name="username" size=50></input>
+    <br>
+    <h3>Enter Identity:</h3>
+    <label>BENE Id or HICN HASH or MBI HASH</label> <input type="text" name="pt_identity" size=80></input>
+    <br>
+    <br>
+    <p><b>Select Identity Type:</b></p>
+    <input type="radio" id="is_hicn_hash" name="beneficiary_identity" value="H" checked="checked">HICN Hash</input>
+    <br>
+    <input type="radio" id="is_mbi_hash" name="beneficiary_identity" value="M">MBI Hash</input>
+    <br>
+    <input type="radio" id="is_bene_id" name="beneficiary_identity" value="S">BENE ID</input>
+    <br>
+    <br>
+    <label>name</label> <input type="text" name="name" size=30></input>
+    <br>
+    <br>
+    <label>given_name</label> <input type="text" name="given_name" size=50></input>
+    <br>
+    <br>
+    <label>family_name</label> <input type="text" name="family_name" size=50></input>
+    <br>
+    <br>
+    <label>email</label> <input type="text" name="email" size=80></input>
+    <br>
+    <br>
+    <input type="hidden" name="state" value="{{ .Get "state" }}"></input>
+    <input type="hidden" name="redirect_uri" value="{{ .Get "redirect_uri" }}"></input>
+    <button type="submit">Sign In</button>
+</div>
 </form>
 `

--- a/dev-local/msls/main.go
+++ b/dev-local/msls/main.go
@@ -33,10 +33,16 @@ SLS_TOKEN_ENDPOINT = env(
 */
 
 const (
-	USERNAME_FIELD = "username"
-	PASSWORD_FIELD = "password"
-	CODE_KEY       = "code"
-	AUTH_HEADER    = "Authorization"
+	USERNAME_FIELD    = "username"
+	NAME_FIELD        = "name"
+	GIVEN_NAME_FIELD  = "given_name"
+	FAMILY_NAME_FIELD = "family_name"
+	EMAIL_FIELD       = "email"
+	IDENTITY_FIELD    = "pt_identity"
+	IDENTITY_TYPE     = "identity_type"
+	CODE_KEY          = "code"
+	AUTH_HEADER       = "Authorization"
+	BENE_IDENTITY     = "beneficiary_identity"
 )
 
 func logRequest(w http.Handler) http.Handler {
@@ -112,37 +118,61 @@ func handleLogin(rw http.ResponseWriter, r *http.Request) {
 
 func login(r *http.Request) code {
 	usr := r.FormValue(USERNAME_FIELD)
-	pwd := r.FormValue(PASSWORD_FIELD)
+	name := r.FormValue(NAME_FIELD)
+	given_name := r.FormValue(GIVEN_NAME_FIELD)
+	family_name := r.FormValue(FAMILY_NAME_FIELD)
+	email := r.FormValue(EMAIL_FIELD)
+	pt_identity := r.FormValue(IDENTITY_FIELD)
+	identity_type := r.FormValue(BENE_IDENTITY)
 
-	return encode(usr, pwd)
+	return encode(usr, name, given_name, family_name, email, pt_identity, identity_type)
 }
 
 type code string
 
 func (c code) userinfo() *userinfo {
-	u, p := decode(string(c))
+	usr, name, given_name, family_name, email, pt_identity, identity_type := decode(string(c))
 	return &userinfo{
-		Sub:  u,
-		Hicn: p,
+		Sub:  usr,
+		Name: name,
+		Given_name: given_name,
+		Family_name: family_name,
+		Email: email,
+		Pt_identity: pt_identity,
+		Identity_type: identity_type,
 	}
 }
 
-func decode(c string) (string, string) {
-	u, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[0])
-	p, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[1])
-	return string(u), string(p)
+func decode(c string) (string, string, string, string, string, string, string) {
+	d_usr, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[0])
+	d_name, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[1])
+	d_given_name, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[2])
+	d_family_name, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[3])
+	d_email, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[4])
+	d_pt_identity, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[5])
+	d_identity_type, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[6])
+	return string(d_usr), string(d_name), string(d_given_name), string(d_family_name),
+	       string(d_email), string(d_pt_identity), string(d_identity_type)
 }
 
-func encode(usr, pwd string) code {
-	u := base64.RawURLEncoding.EncodeToString([]byte(usr))
-	p := base64.RawURLEncoding.EncodeToString([]byte(pwd))
-	return code(fmt.Sprintf("%s.%s", u, p))
+func encode(usr,name, given_name, family_name, email, pt_identity, identity_type string) code {
+	e_usr := base64.RawURLEncoding.EncodeToString([]byte(usr))
+	e_name := base64.RawURLEncoding.EncodeToString([]byte(name))
+	e_given_name := base64.RawURLEncoding.EncodeToString([]byte(given_name))
+	e_family_name := base64.RawURLEncoding.EncodeToString([]byte(family_name))
+	e_email := base64.RawURLEncoding.EncodeToString([]byte(email))
+	e_pt_identity := base64.RawURLEncoding.EncodeToString([]byte(pt_identity))
+	e_identity_type := base64.RawURLEncoding.EncodeToString([]byte(identity_type))
+	return code(fmt.Sprintf("%s.%s.%s.%s.%s.%s.%s", e_usr, e_name, e_given_name,
+                    e_family_name, e_email, e_pt_identity, e_identity_type))
 }
 
 type userinfo struct {
-	Sub        string `json:"sub"`
-	Hicn       string `json:"hicn"`
-	GivenName  string `json:"given_name"`
-	FamilyName string `json:"family_name"`
-	Email      string `json:"email"`
+	Sub         	string `json:"sub"`
+	Name        	string `json:"name"`
+	Given_name  	string `json:"given_name"`
+	Family_name 	string `json:"family_name"`
+	Email       	string `json:"email"`
+	Pt_identity 	string `json:"pt_identity"`
+	Identity_type	string `json:"identity_type"`
 }

--- a/dev-local/toolchains.xml
+++ b/dev-local/toolchains.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF8"?>
+<toolchains>
+	<toolchain>
+		<type>jdk</type>
+		<provides>
+			<version>1.8</version>
+			<vendor>openjdk</vendor>
+			<id>openjdk-8-jdk</id>
+		</provides>
+		<configuration>
+			<jdkHome>/usr/lib/jvm/java-1.8.0-openjdk-amd64</jdkHome>
+		</configuration>
+	</toolchain>
+</toolchains>

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -377,6 +377,10 @@ DEFAULT_DISCLOSURE_TEXT = """
 DISCLOSURE_TEXT = env('DJANGO_PRIVACY_POLICY_URI', DEFAULT_DISCLOSURE_TEXT)
 
 HOSTNAME_URL = env('HOSTNAME_URL', 'http://localhost:8000')
+# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
+# note: if localhost is used instead of IP, run into session overriden issue (don't know why),
+# the sympton is KeyError when get client_id from session;
+# use IP instead works fine
 
 # Set the default Encoding standard. typically 'utf-8'
 ENCODING = 'utf-8'
@@ -473,6 +477,13 @@ USER_ID_TYPE_CHOICES = (('H', 'HICN'),
 
 USER_ID_TYPE_DEFAULT = "H"
 DEFAULT_SAMPLE_FHIR_ID = env("DJANGO_DEFAULT_SAMPLE_FHIR_ID", "-20140000008325")
+
+DEFAULT_SAMPLE_FHIR_ID_HICN = env("DJANGO_DEFAULT_SAMPLE_FHIR_ID_HICN", "-19990000000001")
+
+FHIR_PAT_ID_SYS_URI = "https://bluebutton.cms.gov/resources/identifier/"
+FHIR_PAT_ID_SEARCH_PARAM_HICN = "hicn-hash"
+FHIR_PAT_ID_SEARCH_PARAM_MBI = "mbi-hash"
+FHIR_PAT_ID_SEARCH_PARAM_BEN = "bene-id"
 
 OFFLINE = False
 EXTERNAL_LOGIN_TEMPLATE_NAME = '/v1/accounts/upstream-login'

--- a/hhs_oauth_server/settings/dev.py
+++ b/hhs_oauth_server/settings/dev.py
@@ -6,6 +6,11 @@ SLS_VERIFY_SSL = env('DJANGO_SLS_VERIFY_SSL', False)
 SECRET_KEY = env('DJANGO_SECRET_KEY', '1234567890')
 
 HOSTNAME_URL = env('HOSTNAME_URL', 'http://127.0.0.1:8000')
+# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
+# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
+# note: if localhost is used instead of IP, run into session overriden issue (don't know why),
+# the sympton is KeyError when get client_id from session;
+# use IP instead works fine
 
 DEV_SPECIFIC_APPS = [
     # Installation/Site Specific apps based on  -----------------

--- a/hhs_oauth_server/settings/dev.py
+++ b/hhs_oauth_server/settings/dev.py
@@ -7,7 +7,6 @@ SECRET_KEY = env('DJANGO_SECRET_KEY', '1234567890')
 
 HOSTNAME_URL = env('HOSTNAME_URL', 'http://127.0.0.1:8000')
 # HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
-# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
 # note: if localhost is used instead of IP, run into session overriden issue (don't know why),
 # the sympton is KeyError when get client_id from session;
 # use IP instead works fine

--- a/hhs_oauth_server/settings/dev_local.py
+++ b/hhs_oauth_server/settings/dev_local.py
@@ -6,7 +6,6 @@ SECRET_KEY = env('DJANGO_SECRET_KEY', '1234567890')
 
 HOSTNAME_URL = env('HOSTNAME_URL', 'http://127.0.0.1:8000')
 # HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
-# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
 # note: if localhost is used instead of IP, run into session overriden issue (don't know why),
 # the sympton is KeyError when get client_id from session;
 # use IP instead works fine

--- a/hhs_oauth_server/settings/dev_local.py
+++ b/hhs_oauth_server/settings/dev_local.py
@@ -5,6 +5,11 @@ DEBUG = True
 SECRET_KEY = env('DJANGO_SECRET_KEY', '1234567890')
 
 HOSTNAME_URL = env('HOSTNAME_URL', 'http://127.0.0.1:8000')
+# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
+# HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.187:8000')
+# note: if localhost is used instead of IP, run into session overriden issue (don't know why),
+# the sympton is KeyError when get client_id from session;
+# use IP instead works fine
 
 DEV_SPECIFIC_APPS = [
     # Installation/Site Specific apps based on  -----------------


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-126](https://jira.cms.gov/browse/BB2-126)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a developer working with BB2 in a local development environment (for details refer to: https://github.com/CMSgov/bluebutton-web-server/tree/master/docker-compose), I need the local MSLS service ( a simulator of SLS identity provider service) accept MBI (and MBI Hash) as beneficiary identity in addition to HICN (and HICN Hash). 

Currently, the local MSLS service (implemented in golang) is up and running at localhost:8080 as a dependency service when BB2 service starts, it participates in OAUTH2 flow by collecting beneficiary identity and providing user info (user name (sub), one form of identity: hicn/hicnHash, and optionally: first name, last name, email) to the authentication and authorization flow.

With inclusion of MBI as a form of beneficiary identity, MSLS needs to support mbi/mbiHash as beneficiary identity during simulated SLS authentication and authorization flow.

This change depends on below jira ticket:

[BB2-54:Store MBI hash in crosswalk for use with patient resource lookups](https://jira.cms.gov/browse/BB2-54)

### What Does This PR Do?

<!--
Add detailed discussion of changes here
This is likely a summary, or the complete contents, of your commit messages.
-->

Changes are made in MSLS golang code:

* change login_form.go to extend the web form so that mbi/mbiHash can be collected as identity
* change functions in main.go accordingly to process mbi/mbiHash as beneficiary identity 

Acknowledgement:

The go lang artifacts in MSLS are contributed by David Tisza

Additionally, there are changes in python code to handle mbi / mbi hash.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check these things, in particular:

* The changes in MSLS UX make it easy to use
* MBI and MBI hash is accepted as identity in simulated SLS, and is processed correctly
* HICN and MBI hash is accepted as identity in simulated SLS, and is processed correctly
* UX gives user (developer) sufficient warning not to use real PII, PHI in the simulated SLS service 

<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [ ] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.