### PR TITLE
BB2-126: Update MSLS container to include MBI for local development - msls service

### DIFF
--- a/dev-local/msls/login_form.go
+++ b/dev-local/msls/login_form.go
@@ -45,19 +45,13 @@ submit{
     <label>SUB(username): </label> <input type="text" name="username" size=50></input>
     <br>
     <h3>Enter Identity:</h3>
-    <label>BENE Id, HICN or HICN HASH, MBI or MBI HASH Accepted</label> <input type="text" name="usr_identity" size=64></input>
+    <label>BENE Id, HICN, MBI Accepted</label> <input type="text" name="usr_identity" size=64></input>
     <br>
     <br>
     <p><b>Select Identity Type:</b></p>
     <input type="radio" id="is_hicn" name="beneficiary_identity" value="H" checked="checked">HICN</input>
     <br>
-    <input type="radio" id="is_hicn_hash" name="beneficiary_identity" value="HH" disabled>HICN Hash</input>
-    <br>
     <input type="radio" id="is_mbi" name="beneficiary_identity" value="M">MBI</input>
-    <br>
-    <input type="radio" id="is_mbi_hash" name="beneficiary_identity" value="MH" disabled>MBI Hash</input>
-    <br>
-    <input type="radio" id="is_bene_id" name="beneficiary_identity" value="S" disabled>BENE ID</input>
     <br>
     <br>
     <label>name</label> <input type="text" name="name" size=30></input>

--- a/dev-local/msls/login_form.go
+++ b/dev-local/msls/login_form.go
@@ -45,13 +45,10 @@ submit{
     <label>SUB(username): </label> <input type="text" name="username" size=50></input>
     <br>
     <h3>Enter Identity:</h3>
-    <label>BENE Id, HICN, MBI Accepted</label> <input type="text" name="usr_identity" size=64></input>
+    <label>HICN</label> <input type="text" name="hicn" size=64></input>
     <br>
     <br>
-    <p><b>Select Identity Type:</b></p>
-    <input type="radio" id="is_hicn" name="beneficiary_identity" value="H" checked="checked">HICN</input>
-    <br>
-    <input type="radio" id="is_mbi" name="beneficiary_identity" value="M">MBI</input>
+    <label>MBI</label> <input type="text" name="mbi" size=64></input>
     <br>
     <br>
     <label>name</label> <input type="text" name="name" size=30></input>

--- a/dev-local/msls/login_form.go
+++ b/dev-local/msls/login_form.go
@@ -1,12 +1,80 @@
 package main
 
 var login_template = `
-<form method="post" action="/login">
-<input type="text" name="username"></input>
-<input type="text" name="password"></input>
+<style>
+label{
+    display: inline-block;
+    float: left;
+    clear: left;
+    width: 250px;
+    text-align: left; /*Change to right here if you want it close to the inputs*/
+}
+input {
+  display: inline-block;
+  float: left;
+}
+.container {
+  width: 500px;
+  clear: both;
+}
+.container input {
+  width: 100%;
+  clear: both;
+}
+.txtwrapleft {
+  float: left;
+  margin: 10px;
+}
+submit{
+  padding-left: 100px;
+}
+</style>
 
-<input type="hidden" name="state" value="{{ .Get "state" }}"></input>
-<input type="hidden" name="redirect_uri" value="{{ .Get "redirect_uri" }}"></input>
-<button type="submit">Sign In</button>
+<h1>MSLS Component Inputs for simulating SLS/MyMedicare auth flow locally</h1>
+<p>
+<img class="txtwrapleft" alt="BB2 Local Dev Warning" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAHwAAAB8CAMAAACcwCSMAAAAnFBMVEX/////1CoAAAD/1iqNjY3cuiX/2iv/2Cv/3Sz/3yzHx8fa2trw8PDr6+seHh719fX20Cmrq6vwyyhra2t8fHwxMTFAQEDBwcHj4+OHchddTQ8lIAa3t7e6nR9IPAwVEAPkwiZLS0s5LwnCpCAPDw9VRw5CNgukiRswKAhVVVVmVhGYmJjR0dGukR3OsCNhYWF8aRRzYBORexgdFwXm0SpPAAAFR0lEQVRoge1a63qiMBBdiCTQ1pbauuulWlfXXmy1Vd//3ZbMBAiQBARC/3D6fS0C5Tgx58xM4q9fPXr06NGjR48fx/XV9Q8x3zy6HIO7H+D+dAXG3Uc/vI3J3d+dx/7opvjomPsaWHf7Lfy96Zb8nXPOAhqs+cFjp9x/IOAVcdgBjiZdksNsm1LHcYIZP/zqkPsewg1JRM48OP7sjhz4Xn2HI/jmL/52xj3gdHMK3A5ZPfOXTx1xTyDwjSB3/FfwuY6c5gskHnM7JFx35zRXELjHYnKHLviJf8MuyH9zqu8k8Ch0tuzKaVBmI5KSd+g0KDMp8A6dBmT2HGS4I7nBW7qyzD0ElkU28Cj0KSR2y+QPnGTr57gdMjrbdxqsnQ4kTx47jdXE/hdkFhS4Y6cZWOR+gtk2KgYeOc0GnMae3G7GCpklsUNF9WCNHGT2FiaBE0Zp8kI4ja06OiczQkNvsVixJLvt+OV3S+Qgs5d4ttFwCon8Ze8T+06D1bInxhlTGWA9YpLTjK2QQzY7BrKuBeY4DcgIhuLeAjfKbCWGeDSXyGMBWHOaO5DZSRgr8WRu99sXTvNix2k+QGaxv5DVWSY/UatOM/kHMoszChm9yeT7WG7MitNgNkvqNjHAMRbxBSstBGYzuWhcyuSb5AI98tftthAoM8nUg61MnuZY4TR/WuQGmWWKxmAnk3vplfadBptSOY37U4k7Vj/OBjjVntOAzJ5DOY1T2eEyGd7fg9zacpphVk5IvpfIz45E3rLTwNrPlmTqF7aRyOeZghKdpqXEjtnskK1fmOyvb9mijkEL0Y7TwNrPLlc7CUkhljny9pwGZbYiBvJdrpylsFjRRgsBpn7KF40Zc5/6+YtwunkLATJzSb5aJqHkr6d8B+Of+Onbptx3CpkhZil54TIJW6lpQGZvhd4s+lwlfy30jbHTNFunETJjRXL/mJIrrrN1c6d5V01mJJ8ayYXTNKlpCms/0tMlc/cUzRvbNXSaO0jjU2VvJpn7OW8CQI5OU7+FgLWfs7IpjccV5qO6bW22LKqXmZMx97WSXDhN3ZpGKzPp2RxLRz024DRuPe6JVmZAHibkW03DzsBp6i2LwhLrViUzJE/aBt09Yk7WqWkMMkPypHJX+gCw13Ya7dpPzJ6Yez6ppeR1ncYkM3xy4jK6aREngIudBjcMX3Ux8cipyOhT/Rsk9ZwG1n5eQv1z+acOcZ2Y4SZaZ1kUs9lGraGEna02hxU1vsE6NQ3IbGbmBnpT2BD65TUNNqWqfJEjJ4X6Kn8HdS91mnGJzBAsGHleGGjnOoaOq1bVaxrFToYC/mEb+efzzjN/OhTMqPIGzE2pzOChp1jnxRJOBrusewKZrY0yy3aKZlVc5DSanYwsMh3L3DjtLqppcms/mnDk/jxdEFLCr+40JdlMIJjJ5NrUAhBOU6WFKGwYqqPJLAgdzarEYargNNVkdlHkkRGeKzkN1k6FprQY+UkmN3/mlZ0GZptrTBYYjDzb3RJZRgO15reVOM11FZlhMNJ0L7+/0gYMFo0VuKPnJQOv2W7KADdgjFu9YsOwEjmhm2Xk7edZpdsr1DTQlB4rcUeg1DscVn7JZBModRr0l/I0nsZTWkykt45KvlQC1XJhgaUl4AaMtnEcwsKTuvFqDuyetDYH003djbcBSK23uubps6pumpDrvtACDjMLGOE/RPot/son8jeJAzwm+SfwAxqaswuUT8eDZwWbtdlmBq516FeDh2Pb3KbU8nlb/v9N8GBMqpMvm9zl1cT9x8AKPp5+4nvJPXr06NGjRw/L+A+1m15/RgPGHAAAAABJRU5ErkJggg==">
+<h2>Simulated Authentication no PHI or PII</h2>
+<h2>Use Only Synthetic Beneficiary Info</h2>
+<h2>Enter values to be returned by the SLS user_info endpoint below:</h2>
+</p>
+<br>
+<br>
+<form method="post" action="/login">
+<div>
+    <h3>Enter User Name:</h3>
+    <label>SUB(username): </label> <input type="text" name="username" size=50></input>
+    <br>
+    <h3>Enter Identity:</h3>
+    <label>BENE Id, HICN or HICN HASH, MBI or MBI HASH Accepted</label> <input type="text" name="usr_identity" size=64></input>
+    <br>
+    <br>
+    <p><b>Select Identity Type:</b></p>
+    <input type="radio" id="is_hicn" name="beneficiary_identity" value="H" checked="checked">HICN</input>
+    <br>
+    <input type="radio" id="is_hicn_hash" name="beneficiary_identity" value="HH" disabled>HICN Hash</input>
+    <br>
+    <input type="radio" id="is_mbi" name="beneficiary_identity" value="M">MBI</input>
+    <br>
+    <input type="radio" id="is_mbi_hash" name="beneficiary_identity" value="MH" disabled>MBI Hash</input>
+    <br>
+    <input type="radio" id="is_bene_id" name="beneficiary_identity" value="S" disabled>BENE ID</input>
+    <br>
+    <br>
+    <label>name</label> <input type="text" name="name" size=30></input>
+    <br>
+    <br>
+    <label>given_name</label> <input type="text" name="given_name" size=50></input>
+    <br>
+    <br>
+    <label>family_name</label> <input type="text" name="family_name" size=50></input>
+    <br>
+    <br>
+    <label>email</label> <input type="text" name="email" size=80></input>
+    <br>
+    <br>
+    <input type="hidden" name="state" value="{{ .Get "state" }}"></input>
+    <input type="hidden" name="redirect_uri" value="{{ .Get "redirect_uri" }}"></input>
+    <button type="submit">Sign In</button>
+</div>
 </form>
 `

--- a/dev-local/msls/main.go
+++ b/dev-local/msls/main.go
@@ -131,7 +131,7 @@ func login(r *http.Request) code {
 type code string
 
 func (c code) userinfo() *userinfo {
-	usr, name, given_name, family_name, email, hicn, mbi, identity_type := decode(string(c))
+	usr, name, given_name, family_name, email, hicn, mbi := decode(string(c))
 	return &userinfo{
 		Sub:  usr,
 		Name: name,
@@ -140,11 +140,10 @@ func (c code) userinfo() *userinfo {
 		Email: email,
 		Hicn: hicn,
 		Mbi: mbi,
-		Identity_type: identity_type,
 	}
 }
 
-func decode(c string) (string, string, string, string, string, string, string, string) {
+func decode(c string) (string, string, string, string, string, string, string) {
 	d_usr, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[0])
 	d_name, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[1])
 	d_given_name, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[2])
@@ -152,9 +151,8 @@ func decode(c string) (string, string, string, string, string, string, string, s
 	d_email, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[4])
 	d_hicn, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[5])
 	d_mbi, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[6])
-	d_identity_type, _ := base64.RawURLEncoding.DecodeString(strings.Split(c, ".")[7])
 	return string(d_usr), string(d_name), string(d_given_name), string(d_family_name),
-	       string(d_email), string(d_hicn), string(d_mbi), string(d_identity_type)
+	       string(d_email), string(d_hicn), string(d_mbi)
 }
 
 func encode(usr,name, given_name, family_name, email, usr_identity, identity_type string) code {
@@ -163,7 +161,6 @@ func encode(usr,name, given_name, family_name, email, usr_identity, identity_typ
 	e_given_name := base64.RawURLEncoding.EncodeToString([]byte(given_name))
 	e_family_name := base64.RawURLEncoding.EncodeToString([]byte(family_name))
 	e_email := base64.RawURLEncoding.EncodeToString([]byte(email))
-	e_identity_type := base64.RawURLEncoding.EncodeToString([]byte(identity_type))
 	e_hicn := ""
 	if identity_type == "H" {
 		e_hicn = base64.RawURLEncoding.EncodeToString([]byte(usr_identity))
@@ -172,8 +169,8 @@ func encode(usr,name, given_name, family_name, email, usr_identity, identity_typ
 	if identity_type == "M" {
 		e_mbi = base64.RawURLEncoding.EncodeToString([]byte(usr_identity))
 	}
-	return code(fmt.Sprintf("%s.%s.%s.%s.%s.%s.%s.%s", e_usr, e_name, e_given_name,
-				e_family_name, e_email, e_hicn, e_mbi, e_identity_type))
+	return code(fmt.Sprintf("%s.%s.%s.%s.%s.%s.%s", e_usr, e_name, e_given_name,
+				e_family_name, e_email, e_hicn, e_mbi))
 }
 
 type userinfo struct {
@@ -184,5 +181,4 @@ type userinfo struct {
 	Email       	string `json:"email"`
 	Hicn   			string `json:"hicn"`
 	Mbi   			string `json:"mbi"`
-	Identity_type	string `json:"identity_type"`
 }

--- a/dev-local/msls/main.go
+++ b/dev-local/msls/main.go
@@ -38,11 +38,10 @@ const (
 	GIVEN_NAME_FIELD  = "given_name"
 	FAMILY_NAME_FIELD = "family_name"
 	EMAIL_FIELD       = "email"
-	IDENTITY_FIELD    = "usr_identity"
-	IDENTITY_TYPE     = "identity_type"
+	HICN_FIELD        = "hicn"
+	MBI_FIELD         = "mbi"
 	CODE_KEY          = "code"
 	AUTH_HEADER       = "Authorization"
-	BENE_IDENTITY     = "beneficiary_identity"
 )
 
 func logRequest(w http.Handler) http.Handler {
@@ -122,10 +121,10 @@ func login(r *http.Request) code {
 	given_name := r.FormValue(GIVEN_NAME_FIELD)
 	family_name := r.FormValue(FAMILY_NAME_FIELD)
 	email := r.FormValue(EMAIL_FIELD)
-	usr_identity := r.FormValue(IDENTITY_FIELD)
-	identity_type := r.FormValue(BENE_IDENTITY)
+	hicn := r.FormValue(HICN_FIELD)
+	mbi := r.FormValue(MBI_FIELD)
 
-	return encode(usr, name, given_name, family_name, email, usr_identity, identity_type)
+	return encode(usr, name, given_name, family_name, email, hicn, mbi)
 }
 
 type code string
@@ -155,20 +154,14 @@ func decode(c string) (string, string, string, string, string, string, string) {
 	       string(d_email), string(d_hicn), string(d_mbi)
 }
 
-func encode(usr,name, given_name, family_name, email, usr_identity, identity_type string) code {
+func encode(usr,name, given_name, family_name, email, hicn, mbi string) code {
 	e_usr := base64.RawURLEncoding.EncodeToString([]byte(usr))
 	e_name := base64.RawURLEncoding.EncodeToString([]byte(name))
 	e_given_name := base64.RawURLEncoding.EncodeToString([]byte(given_name))
 	e_family_name := base64.RawURLEncoding.EncodeToString([]byte(family_name))
 	e_email := base64.RawURLEncoding.EncodeToString([]byte(email))
-	e_hicn := ""
-	if identity_type == "H" {
-		e_hicn = base64.RawURLEncoding.EncodeToString([]byte(usr_identity))
-	}
-	e_mbi := ""
-	if identity_type == "M" {
-		e_mbi = base64.RawURLEncoding.EncodeToString([]byte(usr_identity))
-	}
+	e_hicn := base64.RawURLEncoding.EncodeToString([]byte(hicn))
+	e_mbi := base64.RawURLEncoding.EncodeToString([]byte(mbi))
 	return code(fmt.Sprintf("%s.%s.%s.%s.%s.%s.%s", e_usr, e_name, e_given_name,
 				e_family_name, e_email, e_hicn, e_mbi))
 }


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-126](https://jira.cms.gov/browse/BB2-126)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a developer working with BB2 in a local development environment (for details refer to: https://github.com/CMSgov/bluebutton-web-server/tree/master/docker-compose), I need the local MSLS service ( a simulator of SLS identity provider service) accept MBIas beneficiary identity in addition to HICN. 

Currently, the local MSLS service (implemented in golang) is up and running at localhost:8080 as a dependency service when BB2 service starts, it participates in OAUTH2 flow by collecting beneficiary identity and providing user info (user name (sub), one form of identity: hicn, and optionally: first name, last name, email) to the authentication and authorization flow.

With inclusion of MBI as a form of beneficiary identity, MSLS needs to support mbi as beneficiary identity during simulated SLS authentication and authorization flow.

This change depends on below jira ticket:

[BB2-54:Store MBI hash in crosswalk for use with patient resource lookups](https://jira.cms.gov/browse/BB2-54)

### What Does This PR Do?

<!--
Add detailed discussion of changes here
This is likely a summary, or the complete contents, of your commit messages.
-->

Changes are made in MSLS golang code:

* change login_form.go to extend the web form so that mbi/mbiHash can be collected as identity
* change functions in main.go accordingly to process mbi/mbiHash as beneficiary identity 

Acknowledgement:

The go lang artifacts in MSLS are contributed by David Tisza

Note the msls service changes depends on mbi changes made from BB2-54
to fully function.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check these things, in particular:

* The changes in MSLS UX make it easy to use
* MBI is accepted as identity in simulated SLS, and is processed correctly
* HICN is accepted as identity in simulated SLS, and is processed correctly
* UX gives user (developer) sufficient warning not to use real PII, PHI in the simulated SLS service 

<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [ ] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.