### PR TITLE
BB2-66 Fix-logo-display-in-Published-Applications-API

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -142,6 +142,7 @@ class CustomRegisterApplicationForm(forms.ModelForm):
                                                                  app.name)
             logger.info(logmsg)
         app = super().save(*args, **kwargs)
+        app.save()
         uri = app.store_media_file(self.cleaned_data.pop('logo_image', None), "logo.jpg")
         if uri:
             app.logo_uri = uri

--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -7,7 +7,6 @@ from oauth2_provider.forms import AllowForm as DotAllowForm
 from oauth2_provider.models import get_application_model
 from apps.dot_ext.validators import validate_logo_image, validate_notags
 
-
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
 

--- a/apps/dot_ext/tests/test_form_application.py
+++ b/apps/dot_ext/tests/test_form_application.py
@@ -194,17 +194,13 @@ class TestRegisterApplicationForm(BaseApiTest):
         user = self._create_user('hello.world', '123hello456')
         user.groups.add(greetings_group)
         
-        user.save()
-
         # create APP1 and APP2 with logo_image and other required and optional fields
         # persist application object through CustomRegisterApplicationForm
         form_app1 = self.create_app_form_with_logo(app_name='BB2-66-APP-1', user=user, file_name='test_app1_logo.jpg', color='red')
         self.assertFalse(form_app1.errors, "There are error(s) in the new app register form.")
-        form_app1.save()
 
         form_app2 = self.create_app_form_with_logo(app_name='BB2-66-APP-2', user=user, file_name='test_app2_logo.jpg', color='blue')
         self.assertFalse(form_app2.errors, "There are error(s) in the new app register form.")
-        form_app2.save()
 
         # check APP1 and APP2 are saved in django and have correct path pointing to 
         # logo image files, no image overriden 

--- a/apps/dot_ext/tests/test_form_application.py
+++ b/apps/dot_ext/tests/test_form_application.py
@@ -183,27 +183,26 @@ class TestRegisterApplicationForm(BaseApiTest):
         form.is_valid()
         self.assertNotEqual(form.errors.get('logo_image'), None)
 
-
     def test_create_applications_with_logo(self):
         """
         regression test: BB2-66
         """
         greetings_group = self._create_group('Greetings')
-        capability = self._create_capability('Say-Hello-World', [], greetings_group)
         # create user and add it to the read group
         user = self._create_user('hello.world', '123hello456')
         user.groups.add(greetings_group)
-        
         # create APP1 and APP2 with logo_image and other required and optional fields
         # persist application object through CustomRegisterApplicationForm
-        form_app1 = self.create_app_form_with_logo(app_name='BB2-66-APP-1', user=user, file_name='test_app1_logo.jpg', color='red')
+        form_app1 = self.create_app_form_with_logo(app_name='BB2-66-APP-1', user=user,
+                                                   file_name='test_app1_logo.jpg', color='red')
         self.assertFalse(form_app1.errors, "There are error(s) in the new app register form.")
 
-        form_app2 = self.create_app_form_with_logo(app_name='BB2-66-APP-2', user=user, file_name='test_app2_logo.jpg', color='blue')
+        form_app2 = self.create_app_form_with_logo(app_name='BB2-66-APP-2', user=user,
+                                                   file_name='test_app2_logo.jpg', color='blue')
         self.assertFalse(form_app2.errors, "There are error(s) in the new app register form.")
 
-        # check APP1 and APP2 are saved in django and have correct path pointing to 
-        # logo image files, no image overriden 
+        # check APP1 and APP2 are saved in django and have correct path pointing to
+        # logo image files, no image overriden
         app_obj1 = self._get_user_application(user.username, 'BB2-66-APP-1')
         app_obj2 = self._get_user_application(user.username, 'BB2-66-APP-2')
         self.assertIsNotNone(app_obj1.logo_uri)
@@ -211,7 +210,6 @@ class TestRegisterApplicationForm(BaseApiTest):
         self.assertIsNotNone(app_obj2.logo_uri)
         self.assertTrue(app_obj2.logo_uri)
         self.assertNotEqual(app_obj1.logo_uri, app_obj2.logo_uri)
-
 
     def create_app_form_with_logo(self, app_name=None, user=None, file_name=None, color=None):
         """
@@ -230,26 +228,25 @@ class TestRegisterApplicationForm(BaseApiTest):
             logo_file, None, file_name, 'image/jpeg', len(logo_file.getvalue()), None
         )
         app_fields = {'name': app_name,
-            'client_type': 'confidential',
-            'authorization_grant_type': 'authorization-code',
-            'redirect_uris': 'http://localhost:8000/social-auth/complete/oauth2io/',
-            'logo_uri': '',
-            'logo_image': image,
-            'website_uri': '',
-            'description': 'User:' + user.username + ', registered app: ' + app_name,
-            'policy_uri': '',
-            'tos_uri': '',
-            'support_email': '',
-            'support_phone_number': '',
-            'contacts': '',
-            'agree': True
-        }
+                      'client_type': 'confidential',
+                      'authorization_grant_type': 'authorization-code',
+                      'redirect_uris': 'http://localhost:8000/social-auth/complete/oauth2io/',
+                      'logo_uri': '',
+                      'logo_image': image,
+                      'website_uri': '',
+                      'description': 'User:' + user.username + ', registered app: ' + app_name,
+                      'policy_uri': '',
+                      'tos_uri': '',
+                      'support_email': '',
+                      'support_phone_number': '',
+                      'contacts': '',
+                      'agree': True}
         files = {'logo_image': image}
         form = CustomRegisterApplicationForm(user, app_fields, files)
         app_model = form.instance
         app_model.user = user
-        # to simulate the context in BB2 runtime when  
+        # to simulate the context in BB2 runtime when
         # a new CustomRegisterApplicationForm instance is saved
         # as BB2 admin user added a new app with logo
         form.save(commit=False)
-        return form    
+        return form

--- a/apps/dot_ext/tests/test_form_application.py
+++ b/apps/dot_ext/tests/test_form_application.py
@@ -185,7 +185,7 @@ class TestRegisterApplicationForm(BaseApiTest):
 
     def test_create_applications_with_logo(self):
         """
-        regression test: BB2-66
+        regression test: BB2-66: Fix-logo-display-in-Published-Applications-API
         """
         greetings_group = self._create_group('Greetings')
         # create user and add it to the read group

--- a/apps/dot_ext/tests/test_form_application.py
+++ b/apps/dot_ext/tests/test_form_application.py
@@ -248,5 +248,8 @@ class TestRegisterApplicationForm(BaseApiTest):
         form = CustomRegisterApplicationForm(user, app_fields, files)
         app_model = form.instance
         app_model.user = user
-        form.save()
+        # to simulate the context in BB2 runtime when  
+        # a new CustomRegisterApplicationForm instance is saved
+        # as BB2 admin user added a new app with logo
+        form.save(commit=False)
         return form    

--- a/apps/fhir/bluebutton/tests/test_models.py
+++ b/apps/fhir/bluebutton/tests/test_models.py
@@ -8,7 +8,7 @@ from ..models import Crosswalk, check_crosswalks
 class TestModels(BaseApiTest):
 
     def test_require_fhir_id(self):
-        with self.assertRaisesRegexp(IntegrityError, "NOT NULL constraint.*fhir_id"):
+        with self.assertRaisesRegexp(IntegrityError, "[NOT NULL constraint|null value in column].*fhir_id.*"):
             self._create_user('john', 'password',
                               first_name='John',
                               last_name='Smith',
@@ -17,7 +17,7 @@ class TestModels(BaseApiTest):
 
     def test_require_user_hicn_hash(self):
         # NOTE: The user_hicn_hash's DB field name is still user_id_hash in regex below.
-        with self.assertRaisesRegexp(IntegrityError, "NOT NULL constraint.*user_id_hash"):
+        with self.assertRaisesRegexp(IntegrityError, "[NOT NULL constraint|null value in column].*user_id_hash.*"):
             self._create_user('john', 'password',
                               first_name='John',
                               last_name='Smith',

--- a/apps/test.py
+++ b/apps/test.py
@@ -107,6 +107,13 @@ class BaseApiTest(TestCase):
         content = json.loads(response.content.decode("utf-8"))
         return content['access_token']
 
+    def _get_user_application(self, username, app_name):
+        """
+        Helper method that retrieve application with given user and app name.
+        """
+        apps_qs = Application.objects.filter(name__exact=app_name).filter(user__username=username)
+        return apps_qs.first()
+
     def create_token(self, first_name, last_name):
         passwd = '123456'
         user = self._create_user(first_name,


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-66](https://jira.cms.gov/browse/BB2-66)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As BB2 Production Application On boarding Administrator, the current process of adding new applications is login
in as BB2 Admin, and using BB2 Admin Console to add application(s) for a particular user, for detailed steps, refer to 
[BB2-66](https://jira.cms.gov/browse/BB2-66) comments.


Bug / Issue:

If a new application is created through BB2 Admin console, and a logo is uploaded during the process, logo_uri is calculated
from the hash of application object's PK (primary key), due to the bug, when logo_uri is calculated, the application's PK is always None because it is not saved yet, this is causing logo_uri collision for all the applications added in a session.

However, if an application is created and saved without providing logo, and logo is later provided as an update to the application, such collision can be avoided - this can be used as a work round.
 

### What Does This PR Do?

<!--
Add detailed discussion of changes here
This is likely a summary, or the complete contents, of your commit messages.
-->

The fix is to persist the new application object to DB table before logo_uri calculation, such that
a logo_uri with a unique hash from the application's PK is used to save the logo image.

### What Should Reviewers Watch For?

Check the following use cases to verify that the issue is fixed:

Follow steps detailed in [BB2-66](https://jira.cms.gov/browse/BB2-66), create multiple applications and upload logos for each of the applications, note this is done through BB2 Admin interface, note, these applications can belong to one user or multiple users, then login as any of the users from BB2 developer account login page, on the user dash board, all registered applications are shown on the dash board, all applications should have their logos shown correctly, no overwrites. 
  

<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [ ] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.
