### PR TITLE
BB2-132 Use stored MBIs with patient resource lookups

### DIFF
--- a/apps/fhir/bluebutton/models.py
+++ b/apps/fhir/bluebutton/models.py
@@ -134,21 +134,12 @@ class Crosswalk(models.Model):
 
     @user_mbi_hash.setter
     def user_mbi_hash(self, value):
-        if self.pk:
+        # Can update ONLY if previous hash value was None/Null.
+        if self.pk and self._user_mbi_hash is not None:
             raise ValidationError("this value cannot be modified.")
         if self._user_mbi_hash:
             raise ValidationError("this value cannot be modified.")
         self._user_mbi_hash = value
-
-    def set_hicn(self, hicn):
-        if self.pk:
-            raise ValidationError("this value cannot be modified.")
-        self.user_hicn_hash = hash_hicn(hicn)
-
-    def set_mbi(self, mbi):
-        if self.pk:
-            raise ValidationError("this value cannot be modified.")
-        self.user_mbi_hash = hash_mbi(mbi)
 
     def get_fhir_resource_url(self, resource_type):
         # Return the fhir server url

--- a/apps/fhir/bluebutton/tests/test_models.py
+++ b/apps/fhir/bluebutton/tests/test_models.py
@@ -1,3 +1,4 @@
+import uuid
 from django.db.utils import IntegrityError
 from django.core.exceptions import ValidationError
 from apps.test import BaseApiTest
@@ -6,6 +7,30 @@ from ..models import Crosswalk, check_crosswalks
 
 
 class TestModels(BaseApiTest):
+
+    def test_crosswalk_setter_properties(self):
+        '''
+          Test the Crosswalk setters
+          and that they can not be modified once set.
+        '''
+        user = self._create_user('john', 'password',
+                                 first_name='John',
+                                 last_name='Smith',
+                                 email='john@smith.net',
+                                 fhir_id="-20000000000001",
+                                 user_hicn_hash=self.test_hicn_hash,
+                                 user_mbi_hash=self.test_mbi_hash)
+
+        cw = Crosswalk.objects.get(user=user)
+
+        with self.assertRaisesRegexp(ValidationError, "this value cannot be modified."):
+            cw.fhir_id = "-20000000000002"
+
+        with self.assertRaisesRegexp(ValidationError, "this value cannot be modified."):
+            cw.user_hicn_hash = uuid.uuid4()
+
+        with self.assertRaisesRegexp(ValidationError, "this value cannot be modified."):
+            cw.user_mbi_hash = uuid.uuid4()
 
     def test_require_fhir_id(self):
         with self.assertRaisesRegexp(IntegrityError, "[NOT NULL constraint|null value in column].*fhir_id.*"):
@@ -26,14 +51,20 @@ class TestModels(BaseApiTest):
                               user_hicn_hash=None)
 
     def test_not_require_user_mbi_hash(self):
-        # user_mbi_hash can be null for backward compatability,
-        #   so passes thru on save with duplicate user error.
-        self._create_user('john', 'password',
-                          first_name='John',
-                          last_name='Smith',
-                          email='john@smith.net',
-                          fhir_id="-20000000000001",
-                          user_hicn_hash=self.test_hicn_hash)
+        '''
+            user_mbi_hash can be null for backward compatability
+            and also an empty string return value from SLS.
+        '''
+        user = self._create_user('john', 'password',
+                                 first_name='John',
+                                 last_name='Smith',
+                                 email='john@smith.net',
+                                 fhir_id="-20000000000001",
+                                 user_hicn_hash=self.test_hicn_hash,
+                                 user_mbi_hash=None)
+
+        cw = Crosswalk.objects.get(user=user)
+        self.assertEqual(cw.user_mbi_hash, None)
 
     def test_immutable_fhir_id(self):
         user = self._create_user('john', 'password',
@@ -67,9 +98,31 @@ class TestModels(BaseApiTest):
         with self.assertRaises(ValidationError):
             cw.user_mbi_hash = "239e178537ed3bc486e6a7195a47a82a2cd6f46e911660fe9775f6e0dd3f1130"
 
+    def test_mutable_user_mbi_hash_when_null(self):
+        '''
+            Test replacing Null mbi_hash value in crosswalk.
+            Unlike hich_hash, this case is OK if past value was Null/None.
+        '''
+        user = self._create_user('john', 'password',
+                                 first_name='John',
+                                 last_name='Smith',
+                                 email='john@smith.net',
+                                 user_mbi_hash=None)
+
+        cw = Crosswalk.objects.get(user=user)
+        self.assertEqual(cw.user_mbi_hash, None)
+
+        cw.user_mbi_hash = "239e178537ed3bc486e6a7195a47a82a2cd6f46e911660fe9775f6e0dd3f1130"
+        cw.save()
+
+        cw = Crosswalk.objects.get(user=user)
+        self.assertEqual(cw.user_mbi_hash, "239e178537ed3bc486e6a7195a47a82a2cd6f46e911660fe9775f6e0dd3f1130")
+
     def test_crosswalk_real_synth_query_managers(self):
-        # Test the RealCrosswalkManager and SynthCrosswalkManager queryset managers using
-        # the check_crosswalks method.
+        '''
+            Test the RealCrosswalkManager and SynthCrosswalkManager queryset managers using
+            the check_crosswalks method.
+        '''
 
         # Create 5x Real (positive FHIR_ID) users
         for cnt in range(5):

--- a/apps/fhir/bluebutton/tests/test_utils.py
+++ b/apps/fhir/bluebutton/tests/test_utils.py
@@ -215,7 +215,8 @@ class Patient_Resource_Test(BaseApiTest):
         xwalk = Crosswalk()
         xwalk.user = self.user
         xwalk.fhir_id = "Patient/12345"
-        xwalk.set_hicn(uuid.uuid4())
+        xwalk.user_hicn_hash = uuid.uuid4()
+        xwalk.user_mbi_hash = uuid.uuid4()
         xwalk.save()
 
     def test_crosswalk_fhir_id(self):
@@ -233,7 +234,8 @@ class Patient_Resource_Test(BaseApiTest):
         x = Crosswalk()
         x.user = u
         x.fhir_id = "Patient/23456"
-        x.set_hicn(uuid.uuid4())
+        x.user_hicn_hash = uuid.uuid4()
+        x.user_mbi_hash = uuid.uuid4()
         x.save()
 
         result = crosswalk_patient_id(u)

--- a/apps/fhir/server/authentication.py
+++ b/apps/fhir/server/authentication.py
@@ -115,18 +115,24 @@ def match_fhir_id(mbi_hash, hicn_hash, request=None):
         UpstreamServerException: If hicn_hash or mbi_hash search found duplicates.
         NotFound: If both searches did not match a fhir_id.
     """
+    # Get auth flow uuid from request session for logging.
+    if request:
+        auth_uuid = request.session.get('auth_uuid', None)
+    else:
+        auth_uuid = None
+
     # Perform primary lookup using MBI_HASH
     if mbi_hash:
         try:
             fhir_id = search_fhir_id_by_identifier_mbi_hash(mbi_hash, request)
         except UpstreamServerException as err:
-            log_match_fhir_id(None, mbi_hash, hicn_hash, False, "M", str(err))
+            log_match_fhir_id(auth_uuid, None, mbi_hash, hicn_hash, False, "M", str(err))
             # Don't return a 404 because retrying later will not fix this.
             raise UpstreamServerException(str(err))
 
         if fhir_id:
             # Found beneficiary!
-            log_match_fhir_id(fhir_id, mbi_hash, hicn_hash, True, "M",
+            log_match_fhir_id(auth_uuid, fhir_id, mbi_hash, hicn_hash, True, "M",
                               "FOUND beneficiary via mbi_hash")
             return fhir_id, "M"
 
@@ -134,16 +140,16 @@ def match_fhir_id(mbi_hash, hicn_hash, request=None):
     try:
         fhir_id = search_fhir_id_by_identifier_hicn_hash(hicn_hash, request)
     except UpstreamServerException as err:
-        log_match_fhir_id(None, mbi_hash, hicn_hash, False, "H", str(err))
+        log_match_fhir_id(auth_uuid, None, mbi_hash, hicn_hash, False, "H", str(err))
         # Don't return a 404 because retrying later will not fix this.
         raise UpstreamServerException(str(err))
 
     if fhir_id:
         # Found beneficiary!
-        log_match_fhir_id(fhir_id, mbi_hash, hicn_hash, True, "H",
+        log_match_fhir_id(auth_uuid, fhir_id, mbi_hash, hicn_hash, True, "H",
                           "FOUND beneficiary via hicn_hash")
         return fhir_id, "H"
     else:
-        log_match_fhir_id(fhir_id, mbi_hash, hicn_hash, False, None,
+        log_match_fhir_id(auth_uuid, fhir_id, mbi_hash, hicn_hash, False, None,
                           "FHIR ID NOT FOUND for both mbi_hash and hicn_hash")
         raise exceptions.NotFound("The requested Beneficiary has no entry, however this may change")

--- a/apps/fhir/server/loggers.py
+++ b/apps/fhir/server/loggers.py
@@ -1,0 +1,27 @@
+import json
+import logging
+
+
+"""
+  Logger functions for fhir/server module
+"""
+
+logger = logging.getLogger('hhs_server.%s' % __name__)
+
+
+# For use in authentication.log_match_fhir_id()
+def log_match_fhir_id(fhir_id, mbi_hash, hicn_hash,
+                      match_found, hash_lookup_type, hash_lookup_mesg):
+    '''
+        Logging for "fhir.server.authentication.match_fhir_id" type
+        used in match_fhir_id()
+    '''
+    logger.info(json.dumps({
+        "type": "fhir.server.authentication.match_fhir_id",
+        "fhir_id": fhir_id,
+        "mbi_hash": mbi_hash,
+        "hicn_hash": hicn_hash,
+        "match_found": match_found,
+        "hash_lookup_type": hash_lookup_type,
+        "hash_lookup_mesg": hash_lookup_mesg,
+    }))

--- a/apps/fhir/server/loggers.py
+++ b/apps/fhir/server/loggers.py
@@ -5,19 +5,19 @@ import logging
 """
   Logger functions for fhir/server module
 """
-
-logger = logging.getLogger('hhs_server.%s' % __name__)
+match_fhir_id_logger = logging.getLogger('audit.authenticate.match_fhir_id')
 
 
 # For use in authentication.log_match_fhir_id()
-def log_match_fhir_id(fhir_id, mbi_hash, hicn_hash,
+def log_match_fhir_id(auth_uuid, fhir_id, mbi_hash, hicn_hash,
                       match_found, hash_lookup_type, hash_lookup_mesg):
     '''
         Logging for "fhir.server.authentication.match_fhir_id" type
         used in match_fhir_id()
     '''
-    logger.info(json.dumps({
+    match_fhir_id_logger.info(json.dumps({
         "type": "fhir.server.authentication.match_fhir_id",
+        "auth_uuid": auth_uuid,
         "fhir_id": fhir_id,
         "mbi_hash": mbi_hash,
         "hicn_hash": hicn_hash,

--- a/apps/fhir/server/tests/responses.py
+++ b/apps/fhir/server/tests/responses.py
@@ -46,8 +46,8 @@ responses = {
                                 "value":"-20000000002346"
                             },
                             {
-                                "system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-                                "value":"50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b"
+                                "system":"https://bluebutton.cms.gov/resources/identifier/mbi-hash",
+                                "value":"98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
                             }
                         ],
                         "name":[
@@ -98,7 +98,6 @@ responses = {
                     "url":"https://sandbox.bluebutton.cms.gov/v1/fhir/Patient/?_count=10&_format=application%2Fjson%2Bfhir&_id=-20000000002346&startIndex=0"
                 }
             ],
-            "entry":[],
         },
     },
     "error": {
@@ -149,8 +148,8 @@ responses = {
                                 "value":"-20000000002346"
                             },
                             {
-                                "system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-                                "value":"50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b"
+                                "system":"https://bluebutton.cms.gov/resources/identifier/mbi-hash",
+                                "value":"98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
                             }
                         ],
                         "name":[
@@ -193,8 +192,8 @@ responses = {
                                 "value":"-20000000002346"
                             },
                             {
-                                "system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-                                "value":"50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b"
+                                "system":"https://bluebutton.cms.gov/resources/identifier/mbi-hash",
+                                "value":"98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
                             }
                         ],
                         "name":[
@@ -266,8 +265,8 @@ responses = {
                                 "value":"-20000000002346"
                             },
                             {
-                                "system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-                                "value":"50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b"
+                                "system":"https://bluebutton.cms.gov/resources/identifier/mbi-hash",
+                                "value":"98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
                             }
                         ],
                         "name":[
@@ -339,8 +338,8 @@ responses = {
                                 "value":"-20000000002346"
                             },
                             {
-                                "system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-                                "value":"50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b"
+                                "system":"https://bluebutton.cms.gov/resources/identifier/mbi-hash",
+                                "value":"98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
                             }
                         ],
                         "name":[
@@ -383,8 +382,8 @@ responses = {
                                 "value":"-20000000002346"
                             },
                             {
-                                "system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash",
-                                "value":"50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b"
+                                "system":"https://bluebutton.cms.gov/resources/identifier/mbi-hash",
+                                "value":"98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
                             }
                         ],
                         "name":[

--- a/apps/fhir/server/tests/test_authentication.py
+++ b/apps/fhir/server/tests/test_authentication.py
@@ -1,59 +1,226 @@
-from django.test import TestCase
-from rest_framework import exceptions
-from requests.exceptions import HTTPError
 from apps.fhir.bluebutton.exceptions import UpstreamServerException
-from httmock import all_requests, HTTMock
-from ..authentication import match_hicn_hash
+from apps.test import BaseApiTest
+from httmock import HTTMock, urlmatch
+from requests.exceptions import HTTPError
+from rest_framework import exceptions
+from ..authentication import match_fhir_id
 from .responses import responses
 
 
-class TestAuthentication(TestCase):
+class TestAuthentication(BaseApiTest):
 
-    def test_match_hicn_hash_success(self):
-        @all_requests
-        def fhir_mock(url, request):
-            return responses['success']
-        with HTTMock(fhir_mock):
-            fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
-            self.assertEqual(backend_data, responses['success']['content'])
+    MOCK_FHIR_URL = "fhir.backend.bluebutton.hhsdevcloud.us"
+    MOCK_FHIR_PATH = "/v1/fhir/Patient/"
+    MOCK_FHIR_HICN_QUERY = ".*hicnHash.*"
+    MOCK_FHIR_MBI_QUERY = ".*mbi-hash.*"
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_HICN_QUERY)
+    def fhir_match_hicn_success_mock(self, url, request):
+        return responses['success']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_HICN_QUERY)
+    def fhir_match_hicn_not_found_mock(self, url, request):
+        return responses['not_found']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_HICN_QUERY)
+    def fhir_match_hicn_error_mock(self, url, request):
+        return responses['error']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_HICN_QUERY)
+    def fhir_match_hicn_duplicates_mock(self, url, request):
+        return responses['duplicates']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_HICN_QUERY)
+    def fhir_match_hicn_malformed_mock(self, url, request):
+        return responses['malformed']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_HICN_QUERY)
+    def fhir_match_hicn_lying_mock(self, url, request):
+        return responses['lying']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_MBI_QUERY)
+    def fhir_match_mbi_success_mock(self, url, request):
+        return responses['success']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_MBI_QUERY)
+    def fhir_match_mbi_not_found_mock(self, url, request):
+        return responses['not_found']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_MBI_QUERY)
+    def fhir_match_mbi_error_mock(self, url, request):
+        return responses['error']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_MBI_QUERY)
+    def fhir_match_mbi_duplicates_mock(self, url, request):
+        return responses['duplicates']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_MBI_QUERY)
+    def fhir_match_mbi_malformed_mock(self, url, request):
+        return responses['malformed']
+
+    @urlmatch(netloc=MOCK_FHIR_URL, path=MOCK_FHIR_PATH, query=MOCK_FHIR_MBI_QUERY)
+    def fhir_match_mbi_lying_mock(self, url, request):
+        return responses['lying']
+
+    def test_match_fhir_id_success(self):
+        '''
+            Testing responses: HICN = success
+                               MBI = success
+            Expecting: Match via MBI first / hash_lockup_type="M"
+        '''
+        with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_success_mock):
+            fhir_id, hash_lookup_type = match_fhir_id(
+                mbi_hash=self.test_mbi_hash,
+                hicn_hash=self.test_hicn_hash)
             self.assertEqual(fhir_id, "-20000000002346")
+            self.assertEqual(hash_lookup_type, "M")
 
-    def test_match_hicn_hash_not_found(self):
-        @all_requests
-        def fhir_mock(url, request):
-            return responses['not_found']
-        with HTTMock(fhir_mock):
+    def test_match_fhir_id_hicn_success(self):
+        '''
+            Testing responses: HICN = success
+                               MBI = not_found
+            Expecting: Match via HICN / hash_lockup_type="H"
+        '''
+        with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_not_found_mock):
+            fhir_id, hash_lookup_type = match_fhir_id(
+                mbi_hash=self.test_mbi_hash,
+                hicn_hash=self.test_hicn_hash)
+            self.assertEqual(fhir_id, "-20000000002346")
+            self.assertEqual(hash_lookup_type, "H")
+
+    def test_match_fhir_id_mbi_success(self):
+        '''
+            Testing responses: HICN = not_found
+                               MBI = success
+            Expecting: Match via MBI / hash_lockup_type="M"
+        '''
+        with HTTMock(self.fhir_match_hicn_not_found_mock, self.fhir_match_mbi_success_mock):
+            fhir_id, hash_lookup_type = match_fhir_id(
+                mbi_hash=self.test_mbi_hash,
+                hicn_hash=self.test_hicn_hash)
+            self.assertEqual(fhir_id, "-20000000002346")
+            self.assertEqual(hash_lookup_type, "M")
+
+    def test_match_fhir_id_not_found(self):
+        '''
+            Testing responses: HICN = not_found
+                               MBI = not_found
+            Expecting: NotFound exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_not_found_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaises(exceptions.NotFound):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
 
-    def test_match_hicn_hash_server_error(self):
-        @all_requests
-        def fhir_mock(url, request):
-            return responses['error']
-        with HTTMock(fhir_mock):
+    def test_match_fhir_id_server_hicn_error(self):
+        '''
+            Testing responses: HICN = error
+                               MBI = not_found
+            Expecting: HTTPError exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_error_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaises(HTTPError):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
 
-    def test_match_hicn_hash_duplicates(self):
-        @all_requests
-        def fhir_mock(url, request):
-            return responses['duplicates']
-        with HTTMock(fhir_mock):
-            with self.assertRaises(UpstreamServerException):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+    def test_match_fhir_id_server_mbi_error(self):
+        '''
+            Testing responses: HICN = not_found
+                               MBI = error
+            Expecting: HTTPError exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_not_found_mock, self.fhir_match_mbi_error_mock):
+            with self.assertRaises(HTTPError):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
 
-    def test_match_hicn_hash_malformed(self):
-        @all_requests
-        def fhir_mock(url, request):
-            return responses['malformed']
-        with HTTMock(fhir_mock):
-            with self.assertRaises(KeyError):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+    def test_match_fhir_id_duplicates_hicn(self):
+        '''
+            Testing responses: HICN = duplicates
+                               MBI = not_found
+            Expecting: UpstreamServerException exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_duplicates_mock, self.fhir_match_mbi_not_found_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
 
-    def test_match_hicn_hash_lying_duplicates(self):
-        @all_requests
-        def fhir_mock(url, request):
-            return responses['lying']
-        with HTTMock(fhir_mock):
-            with self.assertRaises(UpstreamServerException):
-                fhir_id, backend_data = match_hicn_hash("50ad63a61f6bdf977f9796985d8d286a3d10476e5f7d71f16b70b1b4fbdad76b")
+    def test_match_fhir_id_duplicates_mbi(self):
+        '''
+            Testing responses: HICN = success
+                               MBI = duplicates
+            Expecting: UpstreamServerException exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_duplicates_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
+
+    def test_match_fhir_id_duplicates_both(self):
+        '''
+            Testing responses: HICN = duplicates
+                               MBI = duplicates
+            Expecting: UpstreamServerException exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_duplicates_mock, self.fhir_match_mbi_duplicates_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
+
+    def test_match_fhir_id_malformed_hicn(self):
+        '''
+            Testing responses: HICN = malformed
+                               MBI = not_found
+            Expecting: UpstreamServerException exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_malformed_mock, self.fhir_match_mbi_not_found_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Unexpected result found*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
+
+    def test_match_fhir_id_malformed_mbi(self):
+        '''
+            Testing responses: HICN = success
+                               MBI = malformed
+            Expecting: UpstreamServerException exception raised
+        '''
+        with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_malformed_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Unexpected result found*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
+
+    def test_match_fhir_id_lying_hicn(self):
+        '''
+            Testing responses: HICN = lying
+                               MBI = not_found
+            Expecting: UpstreamServerException exception raised
+            Note: lying means response total=1, but there are multiple
+                  Patient resources in the response.
+        '''
+        with HTTMock(self.fhir_match_hicn_lying_mock, self.fhir_match_mbi_not_found_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)
+
+    def test_match_fhir_id_lying_mbi(self):
+        '''
+            Testing responses: HICN = success
+                               MBI = lying
+            Expecting: UpstreamServerException exception raised
+            Note: lying means response total=1, but there are multiple
+                  Patient resources in the response.
+        '''
+        with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_lying_mock):
+            with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
+                fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi_hash=self.test_mbi_hash,
+                    hicn_hash=self.test_hicn_hash)

--- a/apps/mymedicare_cb/loggers.py
+++ b/apps/mymedicare_cb/loggers.py
@@ -1,0 +1,86 @@
+import json
+
+
+"""
+  Logger functions for mymedicare_cb module
+"""
+
+
+# For use in models.get_and_update_user()
+def log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg):
+    '''
+        Logging for info or issue
+        used in get_and_update_user()
+        mesg = Description text.
+    '''
+    logger.info(json.dumps({
+        "type": "mymedicare_cb:get_and_update_user",
+        "fhir_id": fhir_id,
+        "mbi_hash": mbi_hash,
+        "hicn_hash": hicn_hash,
+        "hash_lookup_type": hash_lookup_type,
+        "crosswalk":
+            {
+                "id": user.crosswalk.id,
+                "user_hicn_hash": user.crosswalk.user_hicn_hash,
+                "user_mbi_hash": user.crosswalk.user_mbi_hash,
+                "fhir_id": user.crosswalk.fhir_id,
+                "user_id_type": user.crosswalk.user_id_type,
+            },
+            "mesg": mesg,
+    }))
+
+
+# For use in models.create_beneficiary_record()
+def log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg):
+    '''
+        Logging for info or issue
+        used in create_beneficiary_record()
+        mesg = Description text.
+    '''
+    logger.info(json.dumps({
+        "type": "mymedicare_cb:create_beneficiary_record",
+        "username": username,
+        "fhir_id": fhir_id,
+        "user_mbi_hash": user_mbi_hash,
+        "user_hicn_hash": user_hicn_hash,
+        "mesg": mesg,
+    }))
+
+
+# For use in views.authenticate()
+def log_authenticate_start(logger, sls_status, sls_status_mesg,
+                           sls_subject=None,
+                           sls_mbi_format_valid=None, sls_mbi_format_msg=None,
+                           sls_mbi_format_synthetic=None, sls_hicn_hash=None, sls_mbi_hash=None):
+
+    logger.info(json.dumps({
+        "type": "Authentication:start",
+        "sls_status": sls_status,
+        "sls_status_mesg": sls_status_mesg,
+        "sub": sls_subject,
+        "sls_mbi_format_valid": sls_mbi_format_valid,
+        "sls_mbi_format_msg": sls_mbi_format_msg,
+        "sls_mbi_format_synthetic": sls_mbi_format_synthetic,
+        "sls_hicn_hash": sls_hicn_hash,
+        "sls_mbi_hash": sls_mbi_hash,
+    }))
+
+
+# For use in views.authenticate()
+def log_authenticate_success(logger, sls_subject, user):
+    logger.info(json.dumps({
+        "type": "Authentication:success",
+        "sub": sls_subject,
+        "user": {
+            "id": user.id,
+            "username": user.username,
+            "crosswalk": {
+                "id": user.crosswalk.id,
+                "user_hicn_hash": user.crosswalk.user_hicn_hash,
+                "user_mbi_hash": user.crosswalk.user_mbi_hash,
+                "fhir_id": user.crosswalk.fhir_id,
+                "user_id_type": user.crosswalk.user_id_type,
+            },
+        },
+    }))

--- a/apps/mymedicare_cb/loggers.py
+++ b/apps/mymedicare_cb/loggers.py
@@ -1,20 +1,24 @@
 import json
+import logging
 
 
 """
   Logger functions for mymedicare_cb module
 """
+authenticate_logger = logging.getLogger('audit.authenticate.sls')
+mymedicare_cb_logger = logging.getLogger('audit.authenticate.mymedicare_cb')
 
 
 # For use in models.get_and_update_user()
-def log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg):
+def log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg):
     '''
         Logging for info or issue
         used in get_and_update_user()
         mesg = Description text.
     '''
-    logger.info(json.dumps({
+    mymedicare_cb_logger.info(json.dumps({
         "type": "mymedicare_cb:get_and_update_user",
+        "auth_uuid": auth_uuid,
         "fhir_id": fhir_id,
         "mbi_hash": mbi_hash,
         "hicn_hash": hicn_hash,
@@ -32,14 +36,15 @@ def log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_loo
 
 
 # For use in models.create_beneficiary_record()
-def log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg):
+def log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg):
     '''
         Logging for info or issue
         used in create_beneficiary_record()
         mesg = Description text.
     '''
-    logger.info(json.dumps({
+    mymedicare_cb_logger.info(json.dumps({
         "type": "mymedicare_cb:create_beneficiary_record",
+        "auth_uuid": auth_uuid,
         "username": username,
         "fhir_id": fhir_id,
         "user_mbi_hash": user_mbi_hash,
@@ -49,13 +54,13 @@ def log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user
 
 
 # For use in views.authenticate()
-def log_authenticate_start(logger, sls_status, sls_status_mesg,
-                           sls_subject=None,
+def log_authenticate_start(auth_uuid, sls_status, sls_status_mesg, sls_subject=None,
                            sls_mbi_format_valid=None, sls_mbi_format_msg=None,
                            sls_mbi_format_synthetic=None, sls_hicn_hash=None, sls_mbi_hash=None):
 
-    logger.info(json.dumps({
+    authenticate_logger.info(json.dumps({
         "type": "Authentication:start",
+        "auth_uuid": auth_uuid,
         "sls_status": sls_status,
         "sls_status_mesg": sls_status_mesg,
         "sub": sls_subject,
@@ -68,9 +73,10 @@ def log_authenticate_start(logger, sls_status, sls_status_mesg,
 
 
 # For use in views.authenticate()
-def log_authenticate_success(logger, sls_subject, user):
-    logger.info(json.dumps({
+def log_authenticate_success(auth_uuid, sls_subject, user):
+    authenticate_logger.info(json.dumps({
         "type": "Authentication:success",
+        "auth_uuid": auth_uuid,
         "sub": sls_subject,
         "user": {
             "id": user.id,

--- a/apps/mymedicare_cb/models.py
+++ b/apps/mymedicare_cb/models.py
@@ -33,7 +33,7 @@ def get_and_update_user(subject, mbi_hash, hicn_hash, first_name, last_name, ema
         AssertionError: If a user is matched but not all identifiers match.
     """
     # Match a patient identifier via the backend FHIR server
-    fhir_id, hash_lookup_type = match_fhir_id(mbi_hash=mbi_hash, hicn_hash=hicn_hash, request)
+    fhir_id, hash_lookup_type = match_fhir_id(mbi_hash=mbi_hash, hicn_hash=hicn_hash, request=request)
 
     try:
         # Does an existing user and crosswalk exist for SLS username?

--- a/apps/mymedicare_cb/models.py
+++ b/apps/mymedicare_cb/models.py
@@ -32,6 +32,12 @@ def get_and_update_user(subject, mbi_hash, hicn_hash, first_name, last_name, ema
         KeyError: If response from fhir server is malformed.
         AssertionError: If a user is matched but not all identifiers match.
     """
+    # Get auth flow uuid from request session for logging.
+    if request:
+        auth_uuid = request.session.get('auth_uuid', None)
+    else:
+        auth_uuid = None
+
     # Match a patient identifier via the backend FHIR server
     fhir_id, hash_lookup_type = match_fhir_id(mbi_hash=mbi_hash, hicn_hash=hicn_hash, request=request)
 
@@ -41,38 +47,38 @@ def get_and_update_user(subject, mbi_hash, hicn_hash, first_name, last_name, ema
 
         # TODO: Replace asserts with exception handling.
         if user.crosswalk.user_hicn_hash != hicn_hash:
-            mesg = "Found user's hicn did not match"
-            log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+            err_msg = "Found user's hicn did not match"
+            log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
         assert user.crosswalk.user_hicn_hash == hicn_hash, "Found user's hicn did not match"
 
         if user.crosswalk.fhir_id != fhir_id:
-            mesg = "Found user's fhir_id did not match"
-            log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+            err_msg = "Found user's fhir_id did not match"
+            log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
         assert user.crosswalk.fhir_id == fhir_id, "Found user's fhir_id did not match"
 
         if user.crosswalk.user_mbi_hash is not None:
             if user.crosswalk.user_mbi_hash != mbi_hash:
-                mesg = "Found user's mbi did not match"
-                log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+                err_msg = "Found user's mbi did not match"
+                log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
             assert user.crosswalk.user_mbi_hash == mbi_hash, "Found user's mbi did not match"
         else:
             # Previously stored value was None/Null and mbi_hash != None, update just the mbi hash.
             if mbi_hash is not None:
-                mesg = "UPDATE mbi_hash since previous value was NULL"
-                log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+                err_msg = "UPDATE mbi_hash since previous value was NULL"
+                log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
                 user.crosswalk.user_mbi_hash = mbi_hash
                 user.crosswalk.user_id_type = hash_lookup_type
                 user.crosswalk.save()
 
         # Update hash type used for lookup, if it has changed from last match.
         if user.crosswalk.user_id_type != hash_lookup_type:
-            mesg = "UPDATE user_id_type as it has changed from the previous lookup value"
-            log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+            err_msg = "UPDATE user_id_type as it has changed from the previous lookup value"
+            log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
             user.crosswalk.user_id_type = hash_lookup_type
             user.crosswalk.save()
 
-        mesg = "RETURN existing beneficiary record"
-        log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+        err_msg = "RETURN existing beneficiary record"
+        log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
         return user
     except User.DoesNotExist:
         pass
@@ -84,10 +90,11 @@ def get_and_update_user(subject, mbi_hash, hicn_hash, first_name, last_name, ema
                                      first_name=first_name,
                                      last_name=last_name,
                                      email=email,
-                                     user_id_type=hash_lookup_type)
+                                     user_id_type=hash_lookup_type,
+                                     auth_uuid=auth_uuid)
 
-    mesg = "CREATE beneficiary record"
-    log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+    err_msg = "CREATE beneficiary record"
+    log_get_and_update_user(auth_uuid, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, err_msg)
     return user
 
 
@@ -99,67 +106,68 @@ def create_beneficiary_record(username=None,
                               first_name="",
                               last_name="",
                               email="",
-                              user_id_type="H"):
+                              user_id_type="H",
+                              auth_uuid=None):
 
     # Validate argument values. TODO: Replace asserts with exception handling.
     if username is None:
-        mesg = "username can not be None"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        err_msg = "username can not be None"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
     assert username is not None
 
     if username == "":
-        mesg = "username can not be an empty string"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        err_msg = "username can not be an empty string"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
     assert username != ""
 
     if user_hicn_hash is None:
-        mesg = "user_hicn_hash can not be None"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        err_msg = "user_hicn_hash can not be None"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
         assert user_hicn_hash is not None
     else:
         if len(user_hicn_hash) != 64:
-            mesg = "incorrect user HICN hash format"
-            log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+            err_msg = "incorrect user HICN hash format"
+            log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
         assert len(user_hicn_hash) == 64, "incorrect user HICN hash format"
 
     # If mbi_hash is not NULL, perform length check.
     if user_mbi_hash is not None:
         if len(user_mbi_hash) != 64:
-            mesg = "incorrect user MBI hash format"
-            log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+            err_msg = "incorrect user MBI hash format"
+            log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
         assert len(user_mbi_hash) == 64, "incorrect user MBI hash format"
 
     if fhir_id is None:
-        mesg = "fhir_id can not be None"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        err_msg = "fhir_id can not be None"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
     assert fhir_id is not None
 
     if fhir_id == "":
-        mesg = "fhir_id can not be an empty string"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        err_msg = "fhir_id can not be an empty string"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
     assert fhir_id != ""
 
     if User.objects.filter(username=username).exists():
-        mesg = "user already exists"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
-        raise ValidationError(mesg, username)
+        err_msg = "user already exists"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
+        raise ValidationError(err_msg, username)
 
     if Crosswalk.objects.filter(_user_id_hash=user_hicn_hash).exists():
-        mesg = "user_hicn_hash already exists"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
-        raise ValidationError(mesg, user_hicn_hash)
+        err_msg = "user_hicn_hash already exists"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
+        raise ValidationError(err_msg, user_hicn_hash)
 
     # If mbi_hash is not NULL, perform check for duplicate
     if user_mbi_hash is not None:
         if Crosswalk.objects.filter(_user_mbi_hash=user_mbi_hash).exists():
-            mesg = "user_mbi_hash already exists"
-            log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
-            raise ValidationError(mesg, user_hicn_hash)
+            err_msg = "user_mbi_hash already exists"
+            log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
+            raise ValidationError(err_msg, user_hicn_hash)
 
     if fhir_id and Crosswalk.objects.filter(_fhir_id=fhir_id).exists():
-        mesg = "fhir_id already exists"
-        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
-        raise ValidationError(mesg, fhir_id)
+        err_msg = "fhir_id already exists"
+        log_create_beneficiary_record(auth_uuid, username, fhir_id, user_mbi_hash, user_hicn_hash, err_msg)
+        raise ValidationError(err_msg, fhir_id)
 
     with transaction.atomic():
         user = User(username=username,

--- a/apps/mymedicare_cb/models.py
+++ b/apps/mymedicare_cb/models.py
@@ -1,62 +1,81 @@
 import logging
-from django.db import models, transaction
 from django.contrib.auth.models import User, Group
 from django.core.exceptions import ValidationError
+from django.db import models, transaction
 from apps.accounts.models import UserProfile
-from apps.fhir.server.authentication import match_hicn_hash
-from apps.fhir.bluebutton.models import Crosswalk, hash_hicn, hash_mbi
+from apps.fhir.server.authentication import match_fhir_id
+from apps.fhir.bluebutton.models import Crosswalk
+from .loggers import log_get_and_update_user, log_create_beneficiary_record
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
 
-def get_and_update_user(user_info, request=None):
+def get_and_update_user(subject, mbi_hash, hicn_hash, first_name, last_name, email, request=None):
     """
     Find or create the user associated
     with the identity information from the ID provider.
 
     Args:
-        user_info: Identity response from the userinfo endpoint of the ID provider.
-        request - request from caller to pass along for logging info.
+        Identity parameters passed in from ID provider.
 
+        subject = ID provider's sub or username
+        mbi_hash = Previously hashed mbi
+        hicn_hash = Previously hashed hicn
+        first_name
+        last_name
+        email
+        request - request from caller to pass along for logging info.
     Returns:
         A User
-
     Raises:
         KeyError: If an expected key is missing from user_info.
         KeyError: If response from fhir server is malformed.
         AssertionError: If a user is matched but not all identifiers match.
     """
-    subject = user_info['sub']
-    hicn = user_info['hicn']
-    # Convert SLS's mbi to UPPER case.
-    mbi = user_info['mbi'].upper()
-
-    # If mbi is empty set to None
-    if mbi == "":
-        mbi = None
-
-    # Create hashed values.
-    hicn_hash = hash_hicn(hicn)
-    mbi_hash = hash_mbi(mbi)
-
-    # TODO: Add return for ID type used for FHIR_ID match.
-    # raises exceptions.NotFound:
-    fhir_id, backend_data = match_hicn_hash(hicn_hash, request)
-
-    # HICN was used to match the user.
-    user_id_type = 'H'
+    # Match a patient identifier via the backend FHIR server
+    fhir_id, hash_lookup_type = match_fhir_id(mbi_hash=mbi_hash, hicn_hash=hicn_hash, request)
 
     try:
+        # Does an existing user and crosswalk exist for SLS username?
         user = User.objects.get(username=subject)
+
+        # TODO: Replace asserts with exception handling.
+        if user.crosswalk.user_hicn_hash != hicn_hash:
+            mesg = "Found user's hicn did not match"
+            log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
         assert user.crosswalk.user_hicn_hash == hicn_hash, "Found user's hicn did not match"
+
+        if user.crosswalk.fhir_id != fhir_id:
+            mesg = "Found user's fhir_id did not match"
+            log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
         assert user.crosswalk.fhir_id == fhir_id, "Found user's fhir_id did not match"
+
+        if user.crosswalk.user_mbi_hash is not None:
+            if user.crosswalk.user_mbi_hash != mbi_hash:
+                mesg = "Found user's mbi did not match"
+                log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+            assert user.crosswalk.user_mbi_hash == mbi_hash, "Found user's mbi did not match"
+        else:
+            # Previously stored value was None/Null and mbi_hash != None, update just the mbi hash.
+            if mbi_hash is not None:
+                mesg = "UPDATE mbi_hash since previous value was NULL"
+                log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+                user.crosswalk.user_mbi_hash = mbi_hash
+                user.crosswalk.user_id_type = hash_lookup_type
+                user.crosswalk.save()
+
+        # Update hash type used for lookup, if it has changed from last match.
+        if user.crosswalk.user_id_type != hash_lookup_type:
+            mesg = "UPDATE user_id_type as it has changed from the previous lookup value"
+            log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
+            user.crosswalk.user_id_type = hash_lookup_type
+            user.crosswalk.save()
+
+        mesg = "RETURN existing beneficiary record"
+        log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
         return user
     except User.DoesNotExist:
         pass
-
-    first_name = user_info.get('given_name', "")
-    last_name = user_info.get('family_name', "")
-    email = user_info.get('email', "")
 
     user = create_beneficiary_record(username=subject,
                                      user_hicn_hash=hicn_hash,
@@ -65,7 +84,10 @@ def get_and_update_user(user_info, request=None):
                                      first_name=first_name,
                                      last_name=last_name,
                                      email=email,
-                                     user_id_type=user_id_type)
+                                     user_id_type=hash_lookup_type)
+
+    mesg = "CREATE beneficiary record"
+    log_get_and_update_user(logger, user, fhir_id, mbi_hash, hicn_hash, hash_lookup_type, mesg)
     return user
 
 
@@ -79,21 +101,65 @@ def create_beneficiary_record(username=None,
                               email="",
                               user_id_type="H"):
 
+    # Validate argument values. TODO: Replace asserts with exception handling.
+    if username is None:
+        mesg = "username can not be None"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
     assert username is not None
+
+    if username == "":
+        mesg = "username can not be an empty string"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
     assert username != ""
-    assert user_hicn_hash is not None
-    assert len(user_hicn_hash) == 64, "incorrect user HICN hash format"
+
+    if user_hicn_hash is None:
+        mesg = "user_hicn_hash can not be None"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        assert user_hicn_hash is not None
+    else:
+        if len(user_hicn_hash) != 64:
+            mesg = "incorrect user HICN hash format"
+            log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        assert len(user_hicn_hash) == 64, "incorrect user HICN hash format"
+
+    # If mbi_hash is not NULL, perform length check.
+    if user_mbi_hash is not None:
+        if len(user_mbi_hash) != 64:
+            mesg = "incorrect user MBI hash format"
+            log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        assert len(user_mbi_hash) == 64, "incorrect user MBI hash format"
+
+    if fhir_id is None:
+        mesg = "fhir_id can not be None"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
     assert fhir_id is not None
+
+    if fhir_id == "":
+        mesg = "fhir_id can not be an empty string"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
     assert fhir_id != ""
 
     if User.objects.filter(username=username).exists():
-        raise ValidationError("user already exists", username)
+        mesg = "user already exists"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        raise ValidationError(mesg, username)
 
     if Crosswalk.objects.filter(_user_id_hash=user_hicn_hash).exists():
-        raise ValidationError("user_hicn_hash already exists", user_hicn_hash)
+        mesg = "user_hicn_hash already exists"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        raise ValidationError(mesg, user_hicn_hash)
+
+    # If mbi_hash is not NULL, perform check for duplicate
+    if user_mbi_hash is not None:
+        if Crosswalk.objects.filter(_user_mbi_hash=user_mbi_hash).exists():
+            mesg = "user_mbi_hash already exists"
+            log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+            raise ValidationError(mesg, user_hicn_hash)
 
     if fhir_id and Crosswalk.objects.filter(_fhir_id=fhir_id).exists():
-        raise ValidationError("fhir_id already exists", fhir_id)
+        mesg = "fhir_id already exists"
+        log_create_beneficiary_record(logger, username, fhir_id, user_mbi_hash, user_hicn_hash, mesg)
+        raise ValidationError(mesg, fhir_id)
 
     with transaction.atomic():
         user = User(username=username,
@@ -109,7 +175,7 @@ def create_beneficiary_record(username=None,
                                  user_id_type=user_id_type)
 
         # Extra user information
-        # TODO: remvoe the idea of UserProfile
+        # TODO: remove the idea of UserProfile
         UserProfile.objects.create(user=user, user_type='BEN')
         # TODO: magic strings are bad
         group = Group.objects.get(name='BlueButton')  # TODO: these do not need a group

--- a/apps/mymedicare_cb/tests/test_callback.py
+++ b/apps/mymedicare_cb/tests/test_callback.py
@@ -88,7 +88,8 @@ class MyMedicareBlueButtonClientApiUserInfoTest(TestCase):
         Crosswalk.objects.create(
             user=user,
             fhir_id="-20000000002346",
-            user_hicn_hash="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7")
+            user_hicn_hash="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7",
+            user_mbi_hash="98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321")
         application = Application.objects.create(
             redirect_uris="http://test.com",
             authorization_grant_type='authorization-code',

--- a/apps/mymedicare_cb/validators.py
+++ b/apps/mymedicare_cb/validators.py
@@ -33,7 +33,11 @@ def is_mbi_format_valid(mbi):
                            CHAR_TYPE_N,
                            CHAR_TYPE_N]
     msg = ""
-    # Check length
+    # Check if NoneType.
+    if mbi is None:
+        return False, "Empty"
+
+    # Check length.
     if len(mbi) != 11:
         msg = "Invalid length = {}".format(len(mbi))
         return False, msg
@@ -55,4 +59,8 @@ def is_mbi_format_synthetic(mbi):
     This is the case where there is an "S" in the 2nd position
     denoting a synthetic MBI value.
     """
-    return len(mbi) == 11 and mbi[1] == "S"
+    # Check if NoneType.
+    if mbi is None:
+        return None
+    else:
+        return len(mbi) == 11 and mbi[1] == "S"

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -4,9 +4,6 @@ import requests
 import urllib.request as urllib_request
 import uuid
 
-from apps.dot_ext.models import Approval
-from apps.fhir.bluebutton.exceptions import UpstreamServerException
-from apps.fhir.bluebutton.models import hash_hicn, hash_mbi
 from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db.utils import IntegrityError
@@ -22,12 +19,8 @@ from apps.fhir.bluebutton.exceptions import UpstreamServerException
 from apps.fhir.bluebutton.models import hash_hicn, hash_mbi
 
 from .authorization import OAuth2Config
-from .loggers import (log_authenticate_start, log_authenticate_success)
-
-from .models import (
-    AnonUserState,
-    get_and_update_user,
-)
+from .loggers import log_authenticate_start, log_authenticate_success
+from .models import AnonUserState, get_and_update_user
 from .signals import response_hook
 from .validators import is_mbi_format_valid, is_mbi_format_synthetic
 
@@ -148,7 +141,7 @@ def authenticate(request):
                                hicn_hash=sls_hicn_hash,
                                first_name=sls_first_name,
                                last_name=sls_last_name,
-                               email=sls_email, request)
+                               email=sls_email, request=request)
 
     # Log successful authentication with beneficiary when we return back here.
     log_authenticate_success(authenticate_logger, sls_subject, user)

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -424,6 +424,15 @@ FHIR_SERVER = {
     "CLIENT_AUTH": True,
 }
 
+'''
+    FHIR URL search query parameters for backend /Patient resource
+    See FHIR and/or BFD specs for "identifier" and "_format" params.
+'''
+FHIR_SEARCH_PARAM_IDENTIFIER_MBI_HASH = "https%3A%2F%2Fbluebutton.cms.gov" + \
+                                       "%2Fresources%2Fidentifier%2Fmbi-hash"
+FHIR_SEARCH_PARAM_IDENTIFIER_HICN_HASH = "http%3A%2F%2Fbluebutton.cms.hhs.gov%2Fidentifier%23hicnHash"
+FHIR_PARAM_FORMAT = "json"
+
 # Timeout for request call
 REQUEST_CALL_TIMEOUT = (30, 120)
 # Headers Keep-Alive value

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -429,7 +429,7 @@ FHIR_SERVER = {
     See FHIR and/or BFD specs for "identifier" and "_format" params.
 '''
 FHIR_SEARCH_PARAM_IDENTIFIER_MBI_HASH = "https%3A%2F%2Fbluebutton.cms.gov" + \
-                                       "%2Fresources%2Fidentifier%2Fmbi-hash"
+                                        "%2Fresources%2Fidentifier%2Fmbi-hash"
 FHIR_SEARCH_PARAM_IDENTIFIER_HICN_HASH = "http%3A%2F%2Fbluebutton.cms.hhs.gov%2Fidentifier%23hicnHash"
 FHIR_PARAM_FORMAT = "json"
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,5 +15,5 @@ commands = flake8
 
 [flake8]
 max-line-length = 130
-ignore = F403,F405
+ignore = F403,F405,W503
 exclude = .tox,migrations,docs,examples,bluebutton-css


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-132](https://jira.cms.gov/browse/BB2-132)

**User Story or Bug Summary:**

As a BB Engineer, I need to utilize the MBI hash stored in the crosswalk table so that I can use this identifier to lookup beneficiaries via the patient resource endpoint of the BFD. 

This PR is a continuation of the work done for [BB2-54 Store MBI hash in crosswalk for use with patient resource lookups](https://jira.cms.gov/browse/BB2-54) [PR #806](https://github.com/CMSgov/bluebutton-web-server/pull/806)


### What Does This PR Do?

NOTE: I've changed the discription below, since a lot of rebasing and renamings were done. Please see the details in the commits for more information on those changes.

The following are the main areas of changes related to this PR. I am writing this while doing a self review of the PR. The following is an outline while reviewing the code.

1. apps.mymedicare_cb/views.authenticate()
  This is the first place in the the beneficiary authorization flow where we are receiving MBI and HICN identity information from the SLS provider. This is done using the `userinfo` end point of the SLS identity provider.
    - The imports were sorted for readability and style.
    - Functions were created for the existing logging types:
      - log_authentication_start() - For "Authentication:start"
        - This is newly used to log info prior to exceptions being raised related to possible SLS userinfo end point issues.
        - This is also used to log info related to any validation errors of the returned identity information (described later).
      - log_authentication_success() - For "Authentication:success"
    - The SLS user_info DICT response is no longer passed down to sub functions. The required identity fields are now pulled out in to varialbes with a "sls_" prefix.
      - A new validation is added for checking that the MBI format is standard.
        - This is utilizing the new `validators.is_mbi_format_valid()` function from BB2-54, where it just being used for logging info. From a review of the logs, this has been working well in both sandbox and prod. See:  [CMS MBI ID format information](https://www.cms.gov/Medicare/New-Medicare-Card/Understanding-the-MBI-with-Format.pdf)
      - The hashing of the MBI and HICN values are moved up in to this location. This is to enable the hashing of these just ONCE for performance and logging needs.

2. apps.mymedicare_cb/models.get_and_update_user()
  This is a next sub function in the flow used to FIND or CREATE the user associated with the identity info from SLS.
    - The function arguments were changed from accepting the `user_info` DICT to just the individual variables needed. For example, passing in the unhashed MBI and HICN values are not needed in this lower function, so should not be included.
      - The definition is changed from this:
        ```python
        def get_and_update_user(user_info):
        ```
      - The definition is changed to this:
        ```python
        def get_and_update_user(subject, mbi_hash, hicn_hash, first_name, last_name, email, request=None):
        ```
    - The hashing of the MBI and HICN are removed from here and moved up to the calling function.
    - The request is passed along for logging purposes related to auth_uuid tracing and the BFD Patient resource call.
    - A function was created in loggers.py for any logging related to this function: `log_get_and_update_user()`
      - It is used to log info prior to the ASSERT checks. For an existing user, these are validating the SLS provided identity info against what we previously have in our Crosswalk table.
    - The behavior for updating the crosswalk.user_mbi_hash value if it was previous Null was changed to not update when it is still None/Null.

3. apps.mymedicare_cb.validators.py
  The MBI validation functions were updated to handle the mbi = NoneType case.

4. apps.mymedicare_cb/models.create_beneficiary_record()
  This is a next sub function in the flow used to CREATE the `User`, `UserProfile`, and `Crosswalk` model/table entries.
    - A function was created in loggers.py for any logging related to this function: `log_create_beneficiary_record()`
      - It is used for logging info prior to the ASSTERT checks.

5. apps.fhir.server.authentication.match_fhir_id()
  This is the main function containing the logic for matching an MBI or HICN hash to a patient ID (FHIR_ID) using the back end FHIR service (BFD) Patient resource.
    - The name was changed from the previous `match_hicn_hash()` to `match_fhir_id()`.
      ```python
      def match_fhir_id(mbi_hash, hicn_hash, request=None):
          """
            Matches a patient identifier via the backend FHIR server
            using an MBI or HICN hash.
            Summary:
              - Perform primary lookup using mbi_hash.
              - If there is an mbi_hash lookup issue, raise exception.
              - Perform secondary lookup using HICN_HASH
              - If there is a hicn_hash lookup issue, raise exception.
              - A NotFound exception is raised, if no match was found.
            Returns:
              fhir_id = Matched patient identifier.
              hash_lookup_type = The type used for the successful lookup (M or H).
            Raises exceptions:
              UpstreamServerException: If hicn_hash or mbi_hash search found duplicates.
              NotFound: If both searches did not match a fhir_id.
          """
      ```
    - Logic related to utilizing the mbi_hash as a PRIMARY lookup value and hicn_hash as a SECONDARY was added.
    - A function was created in loggers.py for any logging related to this function: `log_match_fhir_id()`
      - Logging around various exceptions and behaviors were added.
    - The original and new code was refactored for readability as follows:
      - The code related to the searches was split out in to sub functions. This is to make the main matching logic more readable.
      - The following are the new function definitions with comments:
      ```python
      def search_fhir_id_by_identifier_mbi_hash(mbi_hash, request=None):
          """
              Search the back end FHIR server's patient resource
              using the mbi_hash identifier.
          """
      ```
      ```python
      def search_fhir_id_by_identifier_hicn_hash(hicn_hash, request=None):
          """
              Search the back end FHIR server's patient resource
              using the hicn_hash identifier.
          """
      ```
      - A common function is used by those for performing the request to the back end.
      ```python
      def search_fhir_id_by_identifier(search_identifier, request=None):
          """
              Search the backend FHIR server's patient resource
              using the specified identifier.
              Return:  fhir_id = matched ID (or None for no match).
              Raises exception:
                  UpstreamServerException: For backend response issues.
          """
      ```
      - The conditional logic related to parsing and validating the back end response was refactored to check for the "happy path" first.
      - If the FHIR back end search results in multiple entries, the duplicate error message is passed back to the calling function. The caller is to handle, log, and raise the related exception.
      - Various style changes were made for readability.

6. apps.fhir.bluebutton.models.user_mbi_hash()
    - Changed to allow a previously set None/Null value to be updated.

7. hhs_oath_server.settings.base
    - Centralized FHIR URL search query parameters in to the base settings for: FHIR_SEARCH_PARAM_IDENTIFIER_MBIHASH, FHIR_SEARCH_PARAM_IDENTIFIER_HICNHASH, FHIR_PARAM_FORMAT

8. tox.ini
    - Both W503 and W504 are enabled in flake8 by default. These are conflicting rules. The style related to W503 looks to be the new best practice, so added an ignore option in the tox.ini [flake8] section.

9. Resolved an issue for all related logging in this PR.
    - When reviewing audit logs in SPLUNK, discovered that many types are not getting ingested successfully as JSON format and pulling out the fields. To resolve this, logging related to this story was updated to have Python dictionaries converted to JSON using  `json.dumps()` prior to being passed to the logging handler. We are adding a task to our backlog to address logging outside of this PR.

10. apps.fhir.bluebutton.tests.test_models
    - Test added for the Crosswalk setters for "this value cannot be modified." asserts.
    - Added MBI hash related tests similar to existing ones for HICN hash.

11. apps.fhir.bluebutton.tests.test_utils
    - Added MBI hash settings.

12. apps.fhir.server.tests.responses.py
    - Added mbi-hash to mock FHIR server resource responses.

13. apps.fhir.server.tests.test_authentication
    - Sorted imports section for readability.
    - Setup mocks for back end FHIR Patient resource responses using HTTMock and urlmatch from the httmock package.
      - Using the `query` argument to be able to mock the responses based on the query part of the URL.
    - Added tests related to various combinations of results for both mbi_hash and hicn_hash searches.

14. apps.mymedicare_cb.tests.test_callback
    - Added user_mbi_hash value.

15. apps.mymedicare_cb.tests.test_models
    - Added test for creating a new beneficiary with a Null and missing mbi_hash



### What Should Reviewers Watch For?

* Are the unit tests complete? Can you think of additional tests to perform?
* Are there any unhandled and/or untested edge cases you can think of?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
* Naming in general? Do the namings of variables, methods, classes, and other items make sense? Are they too verbose, or not verbose enough? Any redundancies? Are the comments descriptive enough?
* Did the refactoring help with readability?

<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.

### What Needs to Be Merged and Deployed Before this PR?

There are a few open PR's that have overlapping code. Specifically, [BB2-224](https://github.com/CMSgov/bluebutton-web-server/pull/823) should be merged in to master first.  This PR will need to be rebased to update all of the related logging to include the auth_uuid.

### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [X] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.
