### PR TITLE
BB2-190-sls-logger-fail-to-log-event

### DIFF
--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -1,6 +1,7 @@
 import json
 import hashlib
 
+
 class DataAccessGrantSerializer:
     tkn = None
     action = None
@@ -139,6 +140,7 @@ class Response:
     request_class = None
     resp = None
     sender = None
+
     def __init__(self, response, sender):
         self.resp = response
         self.sender = sender

--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -173,14 +173,12 @@ class Response:
             # mask out mbi and hicn
             resp_dict = {'type': 'SLS_userinfo'}
             d = json.loads(self.resp.text)
-            if 'mbi' in d:
-                d['mbi'] = '***********'
-            else:
-                d['mbi'] = None
-            if 'hicn' in d:
-                d['hicn'] = '***********'
-            else:
-                d['hicn'] = None
+            pii_list = ['mbi', 'hicn', 'name', 'given_name', 'family_name', 'email']
+            for i in pii_list:
+                if i in d:
+                    d[i] = '************'
+                else:
+                    d[i] = None
             resp_dict.update(d)
         else:
             resp_dict.update({'error': 'Unexpected sender: {}'.format(self.sender)})

--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -169,6 +169,10 @@ class Response:
         if self.sender == 'token_endpoint':
             resp_dict = {'type': 'SLS_token'}
             resp_dict.update(json.loads(self.resp.text))
+            access_token = resp_dict.get('access_token')
+            if access_token is not None:
+                # replace token with hash
+                resp_dict['access_token'] = hashlib.sha256(access_token.encode('utf-8')).hexdigest()
         elif self.sender == 'userinfo_endpoint':
             # mask out mbi and hicn
             resp_dict = {'type': 'SLS_userinfo'}

--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -2,8 +2,10 @@ import json
 import hashlib
 from enum import Enum, unique
 
+
 def mask_value(value):
     return '*******' if value is not None else ''
+
 
 def hash_value(value):
     return hashlib.sha256(value.encode('utf-8')).hexdigest()
@@ -224,6 +226,7 @@ class Response:
 class FHIRResponse(Response):
     request_class = FHIRRequest
 
+
 class SLSResponse(Response):
     def get_type(self):
         pass
@@ -245,6 +248,7 @@ class SLSResponse(Response):
                     result[e.value] = attr
         return result
 
+
 class SLSTokenResponse(SLSResponse):
     obfuscation_mapper = {
         SLSToken.ACCESS_TOKEN: hash_value,
@@ -265,11 +269,12 @@ class SLSTokenResponse(SLSResponse):
         event_dict = super().to_dict().copy()
         event_dict.update(json.loads(self.resp.text))
         return event_dict
-    
+
     def __str__(self):
         result = self.to_dict()
         result.update(self.req)
         return json.dumps(self.extract_and_obfuscate(result))
+
 
 class SLSUserInfoResponse(SLSResponse):
     obfuscation_mapper = {
@@ -296,7 +301,7 @@ class SLSUserInfoResponse(SLSResponse):
         event_dict = super().to_dict().copy()
         event_dict.update(json.loads(self.resp.text))
         return event_dict
-    
+
     def __str__(self):
         result = self.to_dict()
         result.update(self.req)

--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -1,10 +1,12 @@
 import json
 import hashlib
+import random
 from enum import Enum, unique
 
 
 def mask_value(value):
-    return '*******' if value is not None else ''
+    mask_str = '*' * random.randrange(5, 20)
+    return mask_str if value is not None else ''
 
 
 def hash_value(value):

--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -1,5 +1,58 @@
 import json
 import hashlib
+from enum import Enum, unique
+
+def mask_value(value):
+    return '*******' if value is not None else ''
+
+def hash_value(value):
+    return hashlib.sha256(value.encode('utf-8')).hexdigest()
+
+
+@unique
+class SLSEventType(Enum):
+    SLS_TOKEN = 'SLS_token'
+    SLS_USERINFO = 'SLS_userinfo'
+
+
+@unique
+class SLSEventSender(Enum):
+    SLS_TOKEN_EP = 'token_endpoint'
+    SLS_USERINFO_EP = 'userinfo_endpoint'
+
+
+@unique
+class SLSToken(Enum):
+    TYPE = 'type'
+    CODE = 'code'
+    SIZE = 'size'
+    START_TIME = 'start_time'
+    ELAPSED = 'elapsed'
+    UUID = 'uuid'
+    USER = 'user'
+    APPLICATION = 'application'
+    PATH = 'path'
+    ACCESS_TOKEN = 'access_token'
+
+
+@unique
+class SLSUserInfo(Enum):
+    TYPE = 'type'
+    CODE = 'code'
+    SIZE = 'size'
+    START_TIME = 'start_time'
+    ELAPSED = 'elapsed'
+    UUID = 'uuid'
+    USER = 'user'
+    APPLICATION = 'application'
+    PATH = 'path'
+    SUB = 'sub'
+    NAME = 'name'
+    GIVEN_NAME = 'given_name'
+    FAMILY_NAME = 'family_name'
+    EMAIL = 'email'
+    HICN = 'hicn'
+    MBI = 'mbi'
 
 
 class DataAccessGrantSerializer:
@@ -100,13 +153,13 @@ class SLSRequest(Request):
         return self.req.headers.get('X-Request-ID')
 
     def user(self):
-        return None
+        return 'Unavailable'
 
     def start_time(self):
-        return None
+        return self.req.headers.get('X-SLS-starttime')
 
     def application(self):
-        return None
+        return 'Unavailable'
 
     def path(self):
         return self.req.path_url if self.req.path_url else None
@@ -139,11 +192,9 @@ class FHIRRequest(Request):
 class Response:
     request_class = None
     resp = None
-    sender = None
 
-    def __init__(self, response, sender):
+    def __init__(self, response):
         self.resp = response
-        self.sender = sender
         # http://docs.python-requests.org/en/master/api/#requests.Response.request
         self.req = self.request_class(response.request).to_dict() if response.request else {}
 
@@ -165,36 +216,88 @@ class Response:
         return resp_dict
 
     def __str__(self):
-        resp_dict = None
-        if self.sender == 'token_endpoint':
-            resp_dict = {'type': 'SLS_token'}
-            resp_dict.update(json.loads(self.resp.text))
-            access_token = resp_dict.get('access_token')
-            if access_token is not None:
-                # replace token with hash
-                resp_dict['access_token'] = hashlib.sha256(access_token.encode('utf-8')).hexdigest()
-        elif self.sender == 'userinfo_endpoint':
-            # mask out mbi and hicn
-            resp_dict = {'type': 'SLS_userinfo'}
-            d = json.loads(self.resp.text)
-            pii_list = ['mbi', 'hicn', 'name', 'given_name', 'family_name', 'email']
-            for i in pii_list:
-                if i in d:
-                    d[i] = '************'
-                else:
-                    d[i] = None
-            resp_dict.update(d)
-        else:
-            resp_dict.update({'error': 'Unexpected sender: {}'.format(self.sender)})
         result = self.to_dict().copy()
         result.update(self.req)
-        result.update(resp_dict)
         return json.dumps(result)
 
 
 class FHIRResponse(Response):
     request_class = FHIRRequest
 
-
 class SLSResponse(Response):
+    def get_type(self):
+        pass
+
+    def get_obfuscation_mapper(self):
+        pass
+
+    def extract_and_obfuscate(self, event):
+        result = {'type': self.get_type()}
+        event_schema = self.get_event_schema()
+        obfuscation_mapper = self.get_obfuscation_mapper()
+        if event is not None:
+            for e in event_schema:
+                if e.value in event:
+                    attr = event[e.value]
+                    if e in obfuscation_mapper:
+                        f = obfuscation_mapper[e]
+                        attr = f(attr)
+                    result[e.value] = attr
+        return result
+
+class SLSTokenResponse(SLSResponse):
+    obfuscation_mapper = {
+        SLSToken.ACCESS_TOKEN: hash_value,
+    }
+
     request_class = SLSRequest
+
+    def get_type(self):
+        return SLSEventType.SLS_TOKEN.value
+
+    def get_event_schema(self):
+        return SLSToken
+
+    def get_obfuscation_mapper(self):
+        return SLSTokenResponse.obfuscation_mapper
+
+    def to_dict(self):
+        event_dict = super().to_dict().copy()
+        event_dict.update(json.loads(self.resp.text))
+        return event_dict
+    
+    def __str__(self):
+        result = self.to_dict()
+        result.update(self.req)
+        return json.dumps(self.extract_and_obfuscate(result))
+
+class SLSUserInfoResponse(SLSResponse):
+    obfuscation_mapper = {
+        SLSUserInfo.NAME: mask_value,
+        SLSUserInfo.GIVEN_NAME: mask_value,
+        SLSUserInfo.FAMILY_NAME: mask_value,
+        SLSUserInfo.EMAIL: mask_value,
+        SLSUserInfo.HICN: mask_value,
+        SLSUserInfo.MBI: mask_value,
+    }
+
+    request_class = SLSRequest
+
+    def get_type(self):
+        return SLSEventType.SLS_USERINFO.value
+
+    def get_event_schema(self):
+        return SLSUserInfo
+
+    def get_obfuscation_mapper(self):
+        return SLSUserInfoResponse.obfuscation_mapper
+
+    def to_dict(self):
+        event_dict = super().to_dict().copy()
+        event_dict.update(json.loads(self.resp.text))
+        return event_dict
+    
+    def __str__(self):
+        result = self.to_dict()
+        result.update(self.req)
+        return json.dumps(self.extract_and_obfuscate(result))

--- a/apps/logging/signals.py
+++ b/apps/logging/signals.py
@@ -1,5 +1,6 @@
 import logging
-import sys, traceback
+import sys
+import traceback
 import json
 from oauth2_provider.signals import app_authorized
 from django.db.models.signals import (
@@ -50,6 +51,7 @@ def handle_app_authorized(sender, request, user, application, **kwargs):
     }
     token_logger.info(get_event(json.dumps(result)))
 
+
 def token_removed(sender, instance=None, **kwargs):
     token_logger.info(get_event(Token(instance, action="revoked")))
 
@@ -77,7 +79,7 @@ def get_event(event):
     event_str = None
     try:
         event_str = str(event)
-    except:
+    except Exception:
         exc_type, exc_value, exc_traceback = sys.exc_info()
         event_str = traceback.format_exception(exc_type, exc_value, exc_traceback)
     return event_str

--- a/apps/logging/signals.py
+++ b/apps/logging/signals.py
@@ -18,7 +18,9 @@ from .serializers import (
     DataAccessGrantSerializer,
     FHIRRequest,
     FHIRResponse,
-    SLSResponse,
+    SLSTokenResponse,
+    SLSUserInfoResponse,
+    SLSEventSender,
 )
 
 token_logger = logging.getLogger('audit.authorization.token')
@@ -67,10 +69,8 @@ def fetching_data(sender, request=None, **kwargs):
 def fetched_data(sender, request=None, response=None, **kwargs):
     fhir_logger.info(get_event(FHIRResponse(response)))
 
-
 def sls_hook(sender, response=None, caller=None, **kwargs):
-    sls_logger.info(get_event(SLSResponse(response, sender)))
-
+    sls_logger.info(get_event(sender(response)))
 
 def get_event(event):
     '''

--- a/apps/logging/signals.py
+++ b/apps/logging/signals.py
@@ -18,9 +18,6 @@ from .serializers import (
     DataAccessGrantSerializer,
     FHIRRequest,
     FHIRResponse,
-    SLSTokenResponse,
-    SLSUserInfoResponse,
-    SLSEventSender,
 )
 
 token_logger = logging.getLogger('audit.authorization.token')
@@ -69,8 +66,10 @@ def fetching_data(sender, request=None, **kwargs):
 def fetched_data(sender, request=None, response=None, **kwargs):
     fhir_logger.info(get_event(FHIRResponse(response)))
 
+
 def sls_hook(sender, response=None, caller=None, **kwargs):
     sls_logger.info(get_event(sender(response)))
+
 
 def get_event(event):
     '''

--- a/apps/logging/test_audit_fhir_logger.py
+++ b/apps/logging/test_audit_fhir_logger.py
@@ -1,0 +1,121 @@
+import logging
+import re
+from io import StringIO
+from apps.test import BaseApiTest
+from django.test.client import Client
+from django.urls import reverse
+from httmock import all_requests, HTTMock
+
+
+class FhirReadAuditLoggerTest(BaseApiTest):
+    def setUp(self):
+        # create read and write capabilities
+        self.read_capability = self._create_capability('Read', [])
+        self.write_capability = self._create_capability('Write', [])
+        self._create_capability('patient', [
+            ["GET", r"\/v1\/fhir\/Patient\/\-\d+"],
+            ["GET", r"\/v1\/fhir\/Patient\/\d+"],
+            ["GET", "/v1/fhir/Patient"],
+        ])
+        self._create_capability('coverage', [
+            ["GET", r"\/v1\/fhir\/Coverage\/.+"],
+            ["GET", "/v1/fhir/Coverage"],
+        ])
+        self._create_capability('eob', [
+            ["GET", r"\/v1\/fhir\/ExplanationOfBenefit\/.+"],
+            ["GET", "/v1/fhir/ExplanationOfBenefit"],
+        ])
+        # Setup the RequestFactory
+        self.client = Client()
+        self.token_logger = logging.getLogger('audit.authorization.token')
+        self.token_logger.setLevel(logging.INFO)
+        self.token_stream = StringIO()
+        self.token_ch = logging.StreamHandler(self.token_stream)
+        self.token_ch.setLevel(logging.INFO)
+        self.token_logger.addHandler(self.token_ch)
+        for h in self.token_logger.handlers:
+            self.token_logger.removeHandler(h)
+        self.token_logger.addHandler(self.token_ch)
+
+        self.sls_logger = logging.getLogger('audit.authorization.sls')
+        self.sls_logger.setLevel(logging.INFO)
+        self.sls_stream = StringIO()
+        self.sls_ch = logging.StreamHandler(self.sls_stream)
+        self.sls_ch.setLevel(logging.INFO)
+        self.sls_logger.addHandler(self.sls_ch)
+        for h in self.sls_logger.handlers:
+            self.sls_logger.removeHandler(h)
+        self.sls_logger.addHandler(self.sls_ch)
+
+        self.fhir_logger = logging.getLogger('audit.data.fhir')
+        self.fhir_logger.setLevel(logging.INFO)
+        self.fhir_stream = StringIO()
+        self.fhir_ch = logging.StreamHandler(self.fhir_stream)
+        self.fhir_ch.setLevel(logging.INFO)
+        self.fhir_logger.addHandler(self.fhir_ch)
+        for h in self.fhir_logger.handlers:
+            self.fhir_logger.removeHandler(h)
+        self.fhir_logger.addHandler(self.fhir_ch)
+
+    def tearDown(self):
+        # tear down token logger
+        self.token_logger.removeHandler(self.token_ch)
+        del self.token_logger, self.token_ch, self.token_stream
+        # tear down sls logger
+        self.sls_logger.removeHandler(self.sls_ch)
+        del self.sls_logger, self.sls_ch, self.sls_stream
+        # tear down fhir logger
+        self.fhir_logger.removeHandler(self.fhir_ch)
+        del self.fhir_logger, self.fhir_ch, self.fhir_stream
+
+    def test_fhir_read_audit_logging(self):
+        # create the user
+        first_access_token = self.create_token('John', 'Smith')
+
+        expected_request = {
+            'method': 'GET',
+            'url': 'https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/Patient/-20140000008325/?_format=json',
+            'headers': {
+                'User-Agent': 'python-requests/2.20.0',
+                'Accept-Encoding': 'gzip, deflate',
+                'Accept': '*/*',
+                'Connection': 'keep-alive',
+                'BlueButton-OriginalQueryCounter': '1',
+                'BlueButton-BeneficiaryId': 'patientId:-20140000008325',
+                'BlueButton-Application': 'John_Smith_test',
+                'BlueButton-OriginatingIpAddress': '127.0.0.1',
+                'keep-alive': 'timeout=120, max=10',
+                'BlueButton-OriginalUrl': '/v1/fhir/Patient/-20140000008325',
+                'BlueButton-BackendCall': 'https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/Patient/-20140000008325/',
+            }
+        }
+
+        @all_requests
+        def catchall(url, req):
+            self.assertEqual(expected_request['url'], req.url)
+            self.assertEqual(expected_request['method'], req.method)
+            self.assertDictContainsSubset(expected_request['headers'], req.headers)
+
+            return {
+                'status_code': 200,
+                'content':{"resourceType":"Patient","id":"-20140000008325","extension":[{"url":"https://bluebutton.cms.gov/resources/variables/race","valueCoding":{"system":"https://bluebutton.cms.gov/resources/variables/race","code":"1","display":"White"}}],"identifier":[{"system":"https://bluebutton.cms.gov/resources/variables/bene_id","value":"-20140000008325"},{"system":"https://bluebutton.cms.gov/resources/identifier/hicn-hash","value":"2025fbc612a884853f0c245e686780bf748e5652360ecd7430575491f4e018c5"}],"name":[{"use":"usual","family":"Doe","given":["Jane","X"]}],"gender":"unknown","birthDate":"2014-06-01","address":[{"district":"999","state":"15","postalCode":"99999"}]} # noqa
+            }
+
+        with HTTMock(catchall):
+            response = self.client.get(
+                reverse(
+                    'bb_oauth_fhir_read_or_update_or_delete',
+                    kwargs={'resource_type': 'Patient', 'resource_id': '-20140000008325'}),
+                {'hello': 'world'},
+                Authorization="Bearer %s" % (first_access_token))
+            self.assertEqual(response.status_code, 200)
+            log_entries = self.fhir_stream.getvalue()
+            log_lines = log_entries.splitlines()
+            fhir_data_pattern = '.*"uuid":.*"user":.*"application":.*"path":.*Patient.*'
+            has_fhir_data = False
+            for line in log_lines:
+                if re.match(fhir_data_pattern, line) is not None:
+                    has_fhir_data = True
+            mesg = 'Expect pattern like "uuid": ... "user": ... "application": ... "path": \
+                    "/v1/fhir/Patient/..." in log record, but not found.'
+            self.assertTrue(has_fhir_data, mesg)

--- a/apps/logging/test_audit_loggers.py
+++ b/apps/logging/test_audit_loggers.py
@@ -1,0 +1,229 @@
+import json
+import logging
+import re
+from io import StringIO
+from urllib.parse import urlparse, parse_qs
+from datetime import datetime
+from django.utils.dateparse import parse_duration
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.contrib.auth.models import Group
+from apps.fhir.bluebutton.models import Crosswalk
+from apps.dot_ext.models import Approval, Application, ArchivedToken
+from apps.test import BaseApiTest
+from apps.authorization.models import DataAccessGrant, ArchivedDataAccessGrant
+
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_refresh_token_model,
+)
+
+AccessToken = get_access_token_model()
+RefreshToken = get_refresh_token_model()
+
+
+class SignalBasedAuditLoggingTest(BaseApiTest):
+    """
+    Test audit loggers
+    """
+    def setUp(self):
+        self.callback_url = reverse('mymedicare-sls-callback')
+        self.login_url = reverse('mymedicare-login')
+        Group.objects.create(name='BlueButton')
+
+        self.token_logger = logging.getLogger('audit.authorization.token')
+        self.token_logger.setLevel(logging.INFO)
+        self.token_stream = StringIO()
+        self.token_ch = logging.StreamHandler(self.token_stream)
+        self.token_ch.setLevel(logging.INFO)
+        self.token_logger.addHandler(self.token_ch)
+        for h in self.token_logger.handlers:
+            self.token_logger.removeHandler(h)
+        self.token_logger.addHandler(self.token_ch)
+
+        self.sls_logger = logging.getLogger('audit.authorization.sls')
+        self.sls_logger.setLevel(logging.INFO)
+        self.sls_stream = StringIO()
+        self.sls_ch = logging.StreamHandler(self.sls_stream)
+        self.sls_ch.setLevel(logging.INFO)
+        self.sls_logger.addHandler(self.sls_ch)
+        for h in self.sls_logger.handlers:
+            self.sls_logger.removeHandler(h)
+        self.sls_logger.addHandler(self.sls_ch)
+        self.fhir_logger = logging.getLogger('audit.data.fhir')
+        self.fhir_logger.setLevel(logging.INFO)
+        self.fhir_stream = StringIO()
+        self.fhir_ch = logging.StreamHandler(self.fhir_stream)
+        self.fhir_ch.setLevel(logging.INFO)
+        self.fhir_logger.addHandler(self.fhir_ch)
+        for h in self.fhir_logger.handlers:
+            self.fhir_logger.removeHandler(h)
+        self.fhir_logger.addHandler(self.fhir_ch)
+
+    def tearDown(self):
+        # tear down token logger
+        self.token_logger.removeHandler(self.token_ch)
+        del self.token_logger, self.token_ch, self.token_stream
+        # tear down sls logger
+        self.sls_logger.removeHandler(self.sls_ch)
+        del self.sls_logger, self.sls_ch, self.sls_stream
+        # tear down fhir logger
+        self.fhir_logger.removeHandler(self.fhir_ch)
+        del self.fhir_logger, self.fhir_ch, self.fhir_stream
+
+    def test_appauthz_accesstoken_dataaccess_grantrevoke_logging(self):
+        # Test that there are no errors with cascading deletes
+        redirect_uri = 'http://localhost'
+        # create a user
+        self._create_user('anna', '123456')
+        capability_a = self._create_capability('Capability A', [])
+        capability_b = self._create_capability('Capability B', [])
+        # create an application and add capabilities
+        application = self._create_application(
+            'an app',
+            grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            redirect_uris=redirect_uri)
+        application.scope.add(capability_a, capability_b)
+        # user logs in
+        self.client.login(username='anna', password='123456')
+        # post the authorization form with only one scope selected
+        payload = {
+            'client_id': application.client_id,
+            'response_type': 'code',
+            'redirect_uri': redirect_uri,
+            'scope': ['capability-a'],
+            'expires_in': 86400,
+            'allow': True,
+        }
+        response = self.client.post(reverse('oauth2_provider:authorize'), data=payload)
+        self.client.logout()
+        self.assertEqual(response.status_code, 302)
+        # now extract the authorization code and use it to request an access_token
+        query_dict = parse_qs(urlparse(response['Location']).query)
+        authorization_code = query_dict.pop('code')
+        token_request_data = {
+            'grant_type': 'authorization_code',
+            'code': authorization_code,
+            'redirect_uri': redirect_uri,
+            'client_id': application.client_id,
+            'client_secret': application.client_secret,
+        }
+        response = self.client.post('/v1/o/token/', data=token_request_data)
+        self.assertEqual(response.status_code, 200)
+        # Now we have a token and refresh token
+        tkn = response.json()['access_token']
+        refresh_tkn = response.json()['refresh_token']
+
+        # Test for cascading contraint errors.
+        application_pk = application.pk
+        application.delete()
+        # Test related objects are deleted
+        self.assertFalse(AccessToken.objects.filter(token=tkn).exists())
+        self.assertTrue(ArchivedToken.objects.filter(token=tkn).exists())
+        self.assertFalse(RefreshToken.objects.filter(token=refresh_tkn).exists())
+        self.assertFalse(DataAccessGrant.objects.filter(application__pk=application_pk).exists())
+        self.assertTrue(ArchivedDataAccessGrant.objects.filter(application__pk=application_pk).exists())
+
+        log_entries = self.token_stream.getvalue()
+        log_lines = log_entries.splitlines()
+        app_authorized_pattern = '.*type.*:.*Authorization.*user.*crosswalk.*'
+        accesstoken_authorized_pattern = '.*type.*:.*AccessToken.*action.*authorized.*'
+        accesstoken_revoked_pattern = '.*type.*:.*AccessToken.*action.*revoked.*'
+        dataaccessgrant_revoked_pattern = '.*type.*:.*DataAccessGrant.*action.*revoked.*'
+        has_app_authorized = False
+        has_accesstoken_authorized = False
+        has_accesstoken_revoked = False
+        has_dataaccessgrant_revoked = False
+
+        for line in log_lines:
+            if re.match(app_authorized_pattern, line) is not None:
+                has_app_authorized = True
+            if re.match(accesstoken_authorized_pattern, line) is not None:
+                has_accesstoken_authorized = True
+            if re.match(accesstoken_revoked_pattern, line) is not None:
+                has_accesstoken_revoked = True
+            if re.match(dataaccessgrant_revoked_pattern, line) is not None:
+                has_dataaccessgrant_revoked = True
+        mesg_app_authz = 'Expect "type" : "Authorization" ... in log record, but not found.'
+        mesg_token_authzd = 'Expect "type" : "AccessToken"..."action" : "revoked" ... in log record, but not found.'
+        mesg_token_revoked = 'Expect "type" : "AccessToken"..."action" : "revoked" ... in log record, but not found.'
+        mesg_data_grant_revoked = 'Expect "type" : "DataAccessGrant"..."action" : "revoked" ... in log record, but not found.'
+        self.assertTrue(has_app_authorized, mesg_app_authz)
+        self.assertTrue(has_accesstoken_authorized, mesg_token_authzd)
+        self.assertTrue(has_accesstoken_revoked, mesg_token_revoked)
+        self.assertTrue(has_dataaccessgrant_revoked, mesg_data_grant_revoked)
+
+    def test_app_authorize_logging(self):
+        user = User.objects.create_user(
+            "bob",
+            password="bad")
+        Crosswalk.objects.create(
+            user=user,
+            fhir_id="-20000000002346",
+            user_hicn_hash="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7")
+        application = Application.objects.create(
+            redirect_uris="http://test.com",
+            authorization_grant_type='authorization-code',
+            name="test01",
+            user=user)
+
+        capability_a = self._create_capability('Capability A', [])
+        capability_b = self._create_capability('Capability B', [])
+        application.scope.add(capability_a, capability_b)
+
+        approval = Approval.objects.create(
+            user=user)
+        auth_uri = reverse(
+            'oauth2_provider:authorize-instance',
+            args=[approval.uuid])
+        response = self.client.get(auth_uri, data={
+            "client_id": application.client_id,
+            "redirect_uri": "http://test.com",
+            "response_type": "code"})
+        self.assertEqual(200, response.status_code)
+        approval.refresh_from_db()
+        self.assertEqual(application, approval.application)
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+        response = self.client.post(auth_uri, data={
+            "client_id": "bad",
+            "redirect_uri": "http://test.com",
+            "response_type": "code"})
+        self.assertEqual(302, response.status_code)
+
+        payload = {
+            'client_id': application.client_id,
+            'response_type': 'code',
+            'redirect_uri': 'http://test.com',
+            'scope': ['capability-a'],
+            'expires_in': 86400,
+            'allow': True,
+        }
+        response = self.client.post(auth_uri, data=payload)
+        self.assertEqual(302, response.status_code)
+        self.assertIn("code=", response.url)
+        approval.created_at = datetime.now() - parse_duration("601")
+        approval.save()
+        response = self.client.post(auth_uri, data={
+            "client_id": application.client_id,
+            "redirect_uri": "http://test.com",
+            "response_type": "code"})
+        # functional asserts
+        self.assertEqual(302, response.status_code)
+        log_entry = self.token_stream.getvalue()
+        log_lines = log_entry.splitlines()
+        like_a_app_authz = False
+        # expect record like this:
+        # {"type": "Authorization", "user": {"id": 1, "username": "bob", "crosswalk": {"id": 1, "user_hicn_
+        # hash": "96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7", "user_mbi_hash": null, "fhir_id":
+        # "-20000000002346", "user_id_type": "H"}}, "application": {"id": 1, "name": "test01"}}
+        for line in log_lines:
+            try:
+                json_rec = json.loads(line)
+                if json_rec["type"] == "Authorization" and json_rec["user"] is not None \
+                        and json_rec["application"] is not None:
+                    like_a_app_authz = True
+            except Exception:
+                pass
+        self.assertTrue(like_a_app_authz, "Expect Application Authorization event, Not found in [{}]".format(log_entry))

--- a/apps/logging/test_audit_req_resp_loggers.py
+++ b/apps/logging/test_audit_req_resp_loggers.py
@@ -1,0 +1,122 @@
+import json
+import logging
+from io import StringIO
+from datetime import datetime
+from django.utils.dateparse import parse_duration
+from django.urls import reverse
+from django.contrib.auth.models import User
+from django.contrib.auth.models import Group
+from apps.fhir.bluebutton.models import Crosswalk
+from apps.dot_ext.models import Approval, Application
+from apps.test import BaseApiTest
+
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_refresh_token_model,
+)
+
+AccessToken = get_access_token_model()
+RefreshToken = get_refresh_token_model()
+
+
+class HTTPReqRespAuditLoggingTest(BaseApiTest):
+    """
+    Test audit loggers
+    """
+    def setUp(self):
+        self.callback_url = reverse('mymedicare-sls-callback')
+        self.login_url = reverse('mymedicare-login')
+        Group.objects.create(name='BlueButton')
+
+        self.http_reqresp_logger = logging.getLogger('audit.hhs_oauth_server.request_logging')
+        self.http_reqresp_logger.setLevel(logging.INFO)
+        self.http_reqresp_stream = StringIO()
+        self.http_reqresp_ch = logging.StreamHandler(self.http_reqresp_stream)
+        self.http_reqresp_ch.setLevel(logging.INFO)
+        self.http_reqresp_logger.addHandler(self.http_reqresp_ch)
+        for h in self.http_reqresp_logger.handlers:
+            self.http_reqresp_logger.removeHandler(h)
+        self.http_reqresp_logger.addHandler(self.http_reqresp_ch)
+
+    def tearDown(self):
+        # tear down http req resp audit logger
+        self.http_reqresp_logger.removeHandler(self.http_reqresp_ch)
+        del self.http_reqresp_logger, self.http_reqresp_ch, self.http_reqresp_stream
+
+    def test_http_req_resp_audit_logging(self):
+        user = User.objects.create_user(
+            "bob",
+            password="bad")
+        Crosswalk.objects.create(
+            user=user,
+            fhir_id="-20000000002346",
+            user_hicn_hash="96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7")
+        application = Application.objects.create(
+            redirect_uris="http://test.com",
+            authorization_grant_type='authorization-code',
+            name="test01",
+            user=user)
+
+        capability_a = self._create_capability('Capability A', [])
+        capability_b = self._create_capability('Capability B', [])
+        application.scope.add(capability_a, capability_b)
+
+        approval = Approval.objects.create(
+            user=user)
+        auth_uri = reverse(
+            'oauth2_provider:authorize-instance',
+            args=[approval.uuid])
+        response = self.client.get(auth_uri, data={
+            "client_id": application.client_id,
+            "redirect_uri": "http://test.com",
+            "response_type": "code"})
+        self.assertEqual(200, response.status_code)
+        approval.refresh_from_db()
+        self.assertEqual(application, approval.application)
+        self.assertNotIn('_auth_user_id', self.client.session)
+
+        response = self.client.post(auth_uri, data={
+            "client_id": "bad",
+            "redirect_uri": "http://test.com",
+            "response_type": "code"})
+        self.assertEqual(302, response.status_code)
+
+        payload = {
+            'client_id': application.client_id,
+            'response_type': 'code',
+            'redirect_uri': 'http://test.com',
+            'scope': ['capability-a'],
+            'expires_in': 86400,
+            'allow': True,
+        }
+        response = self.client.post(auth_uri, data=payload)
+        self.assertEqual(302, response.status_code)
+        self.assertIn("code=", response.url)
+        approval.created_at = datetime.now() - parse_duration("601")
+        approval.save()
+        response = self.client.post(auth_uri, data={
+            "client_id": application.client_id,
+            "redirect_uri": "http://test.com",
+            "response_type": "code"})
+        # functional asserts
+        self.assertEqual(302, response.status_code)
+        log_entry = self.http_reqresp_stream.getvalue()
+        log_lines = log_entry.splitlines()
+        # {"start_time": 1594919285.813495, "end_time": 1594919285.822201, "request_uuid": "ea44a94c-c786-11ea-a01b-024
+        # 2ac1b0004", "path": "/v1/o/authorize/d270a063-f30a-4c37-af52-ff4d35abbb9b/", "response_code": 302, "size": ""
+        # , "location": "http://test.com?code=tRThAPj03WMPquNpvyujHpgeiygaOn", "app_name": "", "app_id": "", "dev_id":
+        # "", "dev_name": "", "access_token_hash": "", "user": "bob", "ip_addr": "127.0.0.1"}
+        for line in log_lines:
+            json_rec = json.loads(line)
+            self.assertTrue(json_rec["start_time"] is not None)
+            self.assertTrue(json_rec["end_time"] is not None)
+            self.assertTrue(json_rec["request_uuid"] is not None)
+            self.assertTrue("path" in json_rec)
+            self.assertTrue("location" in json_rec)
+            self.assertTrue("app_name" in json_rec)
+            self.assertTrue("app_id" in json_rec)
+            self.assertTrue("dev_name" in json_rec)
+            self.assertTrue("dev_id" in json_rec)
+            self.assertTrue("user" in json_rec)
+            self.assertTrue("access_token_hash" in json_rec)
+            self.assertTrue("ip_addr" in json_rec)

--- a/apps/logging/test_sls_logger_resp_hook.py
+++ b/apps/logging/test_sls_logger_resp_hook.py
@@ -1,0 +1,159 @@
+import logging
+import re
+
+from io import StringIO
+from django.urls import reverse
+from apps.mymedicare_cb.views import generate_nonce
+from apps.mymedicare_cb.models import AnonUserState
+from apps.mymedicare_cb.tests.responses import patient_response
+from httmock import urlmatch, all_requests, HTTMock
+from django.contrib.auth.models import Group
+from apps.test import BaseApiTest
+
+from oauth2_provider.models import (
+    get_access_token_model,
+    get_refresh_token_model,
+)
+
+AccessToken = get_access_token_model()
+RefreshToken = get_refresh_token_model()
+
+
+# paste from python requests sessions
+def dispatch_hook(key, hooks, hook_data, **kwargs):
+    """Dispatches a hook dictionary on a given piece of data."""
+    hooks = hooks or {}
+    hooks = hooks.get(key)
+    if hooks:
+        if hasattr(hooks, '__call__'):
+            hooks = [hooks]
+        for hook in hooks:
+            _hook_data = hook(hook_data, **kwargs)
+            if _hook_data is not None:
+                hook_data = _hook_data
+    return hook_data
+
+
+class HTTMockRespHook(HTTMock):
+    def intercept(self, request, **kwargs):
+        resp = HTTMock.intercept(self, request, **kwargs)
+        if request.hooks is not None:
+            return dispatch_hook('response', request.hooks, resp, **kwargs)
+        return resp
+
+
+class SignalBasedRespHookLoggingTest(BaseApiTest):
+    """
+    Test logging for MyMedicare login and SLS Callback
+    """
+    def setUp(self):
+        self.callback_url = reverse('mymedicare-sls-callback')
+        self.login_url = reverse('mymedicare-login')
+        Group.objects.create(name='BlueButton')
+
+        self.token_logger = logging.getLogger('audit.authorization.token')
+        self.token_logger.setLevel(logging.INFO)
+        self.token_stream = StringIO()
+        self.token_ch = logging.StreamHandler(self.token_stream)
+        self.token_ch.setLevel(logging.INFO)
+        self.token_logger.addHandler(self.token_ch)
+        for h in self.token_logger.handlers:
+            self.token_logger.removeHandler(h)
+        self.token_logger.addHandler(self.token_ch)
+        self.sls_logger = logging.getLogger('audit.authorization.sls')
+        self.sls_logger.setLevel(logging.INFO)
+        self.sls_stream = StringIO()
+        self.sls_ch = logging.StreamHandler(self.sls_stream)
+        self.sls_ch.setLevel(logging.INFO)
+        self.sls_logger.addHandler(self.sls_ch)
+        for h in self.sls_logger.handlers:
+            self.sls_logger.removeHandler(h)
+        self.sls_logger.addHandler(self.sls_ch)
+        self.fhir_logger = logging.getLogger('audit.data.fhir')
+        self.fhir_logger.setLevel(logging.INFO)
+        self.fhir_stream = StringIO()
+        self.fhir_ch = logging.StreamHandler(self.fhir_stream)
+        self.fhir_ch.setLevel(logging.INFO)
+        self.fhir_logger.addHandler(self.fhir_ch)
+        for h in self.fhir_logger.handlers:
+            self.fhir_logger.removeHandler(h)
+        self.fhir_logger.addHandler(self.fhir_ch)
+
+    def tearDown(self):
+        # tear down token logger
+        self.token_logger.removeHandler(self.token_ch)
+        del self.token_logger, self.token_ch, self.token_stream
+        # tear down sls logger
+        self.sls_logger.removeHandler(self.sls_ch)
+        del self.sls_logger, self.sls_ch, self.sls_stream
+        # tear down fhir logger
+        self.fhir_logger.removeHandler(self.fhir_ch)
+        del self.fhir_logger, self.fhir_ch, self.fhir_stream
+
+    def test_callback_logging(self):
+        # create a state
+        state = generate_nonce()
+        AnonUserState.objects.create(
+            state=state,
+            next_uri="http://www.google.com?client_id=test&redirect_uri=test.com&response_type=token&state=test")
+        # mock sls token endpoint
+
+        @urlmatch(netloc='dev.accounts.cms.gov', path='/v1/oauth/token')
+        def sls_token_mock(url, request):
+            return {
+                'status_code': 200,
+                'content': {'access_token': 'works'},
+            }
+
+        # mock sls user info endpoint
+        @urlmatch(netloc='dev.accounts.cms.gov', path='/v1/oauth/userinfo')
+        def sls_user_info_mock(url, request):
+            return {
+                'status_code': 200,
+                'content': {
+                    'sub': '00112233-4455-6677-8899-aabbccddeeff',
+                    'given_name': '',
+                    'family_name': '',
+                    'email': 'bob@bobserver.bob',
+                    'hicn': '1234567890A',
+                    'mbi': '1SA0A00AA00',
+                },
+            }
+
+        # mock fhir user info endpoint
+        @urlmatch(netloc='fhir.backend.bluebutton.hhsdevcloud.us', path='/v1/fhir/Patient/')
+        def fhir_patient_info_mock(url, request):
+            return {
+                'status_code': 200,
+                'content': patient_response,
+            }
+
+        @all_requests
+        def catchall(url, request):
+            raise Exception(url)
+
+        with HTTMockRespHook(sls_token_mock,
+                             sls_user_info_mock,
+                             fhir_patient_info_mock,
+                             catchall):
+            response = self.client.get(self.callback_url, data={'code': 'test', 'state': state})
+            # assert http redirect
+            self.assertEqual(response.status_code, 302)
+            self.assertIn("client_id=test", response.url)
+            self.assertIn("redirect_uri=test.com", response.url)
+            # self.assertRedirects(response, "http://www.google.com", fetch_redirect_response=False)
+            # assert login
+            self.assertNotIn('_auth_user_id', self.client.session)
+            log_entries = self.sls_stream.getvalue()
+            log_lines = log_entries.splitlines()
+            sls_token_pattern = '.*type.*:.*SLS_token.*'
+            sls_userinfo_pattern = '.*type.*:.*SLS_userinfo.*'
+            has_token = False
+            has_userinfo = False
+            for line in log_lines:
+                if re.match(sls_token_pattern, line) is not None:
+                    has_token = True
+                if re.match(sls_userinfo_pattern, line) is not None:
+                    has_userinfo = True
+            self.assertTrue(has_token, 'Expect "type" : "SLS_token" ... in log record, but not found.')
+            self.assertTrue(has_userinfo, 'Expect "type" : "SLS_userinfo" ... in log record, but not found.')

--- a/apps/mymedicare_cb/authorization.py
+++ b/apps/mymedicare_cb/authorization.py
@@ -1,7 +1,7 @@
 import logging
 import requests
 from django.conf import settings
-from .signals import response_hook
+from .signals import response_hook_wrapper
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
@@ -39,7 +39,7 @@ class OAuth2Config(object):
                                  auth=self.basic_auth(),
                                  json=token_dict,
                                  verify=self.verify_ssl,
-                                 hooks={'response': response_hook})
+                                 hooks={'response': [response_hook_wrapper(sender='token_endpoint')]})
 
         response.raise_for_status()
 

--- a/apps/mymedicare_cb/authorization.py
+++ b/apps/mymedicare_cb/authorization.py
@@ -41,13 +41,14 @@ class OAuth2Config(object):
         # keep using deprecated conv - no conflict issue
         headers = {"X-SLS-starttime": str(datetime.datetime.utcnow())}
         if request is not None:
-            headers.update({"X-Request-ID": str(getattr(request, '_logging_uuid', None) if hasattr(request, '_logging_uuid') else '')})
+            headers.update({"X-Request-ID": str(getattr(request, '_logging_uuid', None)
+                            if hasattr(request, '_logging_uuid') else '')})
         response = requests.post(self.token_endpoint,
-                                 auth = self.basic_auth(),
-                                 json = token_dict,
-                                 headers = headers,
-                                 verify = self.verify_ssl,
-                                 hooks = {'response': [response_hook_wrapper(sender=SLSTokenResponse)]})
+                                 auth=self.basic_auth(),
+                                 json=token_dict,
+                                 headers=headers,
+                                 verify=self.verify_ssl,
+                                 hooks={'response': [response_hook_wrapper(sender=SLSTokenResponse)]})
 
         response.raise_for_status()
 

--- a/apps/mymedicare_cb/authorization.py
+++ b/apps/mymedicare_cb/authorization.py
@@ -1,7 +1,10 @@
 import logging
 import requests
+import datetime
+
 from django.conf import settings
 from .signals import response_hook_wrapper
+from apps.logging.serializers import SLSTokenResponse
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 
@@ -25,7 +28,7 @@ class OAuth2Config(object):
             return (self.client_id, self.client_secret)
         return None
 
-    def exchange(self, code):
+    def exchange(self, code, request):
         logger.debug("token_endpoint %s" % (self.token_endpoint))
         logger.debug("redirect_uri %s" % (self.redirect_uri))
 
@@ -35,11 +38,16 @@ class OAuth2Config(object):
             "redirect_uri": self.redirect_uri,
         }
 
+        # keep using deprecated conv - no conflict issue
+        headers = {"X-SLS-starttime": str(datetime.datetime.utcnow())}
+        if request is not None:
+            headers.update({"X-Request-ID": str(getattr(request, '_logging_uuid', None) if hasattr(request, '_logging_uuid') else '')})
         response = requests.post(self.token_endpoint,
-                                 auth=self.basic_auth(),
-                                 json=token_dict,
-                                 verify=self.verify_ssl,
-                                 hooks={'response': [response_hook_wrapper(sender='token_endpoint')]})
+                                 auth = self.basic_auth(),
+                                 json = token_dict,
+                                 headers = headers,
+                                 verify = self.verify_ssl,
+                                 hooks = {'response': [response_hook_wrapper(sender=SLSTokenResponse)]})
 
         response.raise_for_status()
 

--- a/apps/mymedicare_cb/signals.py
+++ b/apps/mymedicare_cb/signals.py
@@ -3,5 +3,8 @@ import django.dispatch
 post_sls = django.dispatch.Signal(providing_args=["response"])
 
 
-def response_hook(response, *args, **kwargs):
-    post_sls.send_robust(None, response=response)
+def response_hook_wrapper(*wrapper_args, **wrapper_kwargs):
+    def response_hook(response, *req_args, **req_kwargs):
+        post_sls.send_robust(wrapper_kwargs['sender'], response=response)
+        return response
+    return response_hook

--- a/apps/mymedicare_cb/tests/test_callback.py
+++ b/apps/mymedicare_cb/tests/test_callback.py
@@ -226,7 +226,7 @@ class MyMedicareBlueButtonClientApiUserInfoTest(TestCase):
                 }
 
             with HTTMock(catchall):
-                tkn = sls_client.exchange("test_code")
+                tkn = sls_client.exchange("test_code", None)
                 self.assertEquals(tkn, "test_tkn")
 
     def test_failed_sls_token_exchange(self):
@@ -248,5 +248,5 @@ class MyMedicareBlueButtonClientApiUserInfoTest(TestCase):
 
             with HTTMock(catchall):
                 with self.assertRaises(requests.exceptions.HTTPError):
-                    tkn = sls_client.exchange("test_code")
+                    tkn = sls_client.exchange("test_code", None)
                     self.assertEquals(tkn, "test_tkn")

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -20,7 +20,7 @@ from django.core.exceptions import ValidationError
 from rest_framework.exceptions import NotFound
 from django.views.decorators.cache import never_cache
 from .authorization import OAuth2Config
-from .signals import response_hook
+from .signals import response_hook_wrapper
 from apps.dot_ext.models import Approval
 from apps.fhir.bluebutton.exceptions import UpstreamServerException
 from apps.fhir.bluebutton.models import hash_hicn, hash_mbi
@@ -54,7 +54,7 @@ def authenticate(request):
     response = requests.get(userinfo_endpoint,
                             headers=headers,
                             verify=sls_client.verify_ssl,
-                            hooks={'response': response_hook})
+                            hooks={'response': [response_hook_wrapper(sender='userinfo_endpoint')]})
 
     try:
         response.raise_for_status()

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -55,7 +55,8 @@ def authenticate(request):
     # keep using deprecated conv - no conflict issue
     headers.update({"X-SLS-starttime": str(datetime.datetime.utcnow())})
     if request is not None:
-        headers.update({"X-Request-ID": str(getattr(request, '_logging_uuid', None) if hasattr(request, '_logging_uuid') else '')})
+        headers.update({"X-Request-ID": str(getattr(request, '_logging_uuid', None)
+                        if hasattr(request, '_logging_uuid') else '')})
     response = requests.get(userinfo_endpoint,
                             headers=headers,
                             verify=sls_client.verify_ssl,

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -1,21 +1,23 @@
+import random
+import requests
+import logging
+import datetime
+import urllib.request as urllib_request
+
 from django.conf import settings
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-import requests
 from django.http import JsonResponse
 from django.template.response import TemplateResponse
-import urllib.request as urllib_request
 from urllib.parse import (
     urlsplit,
     urlunsplit,
 )
-import random
 from .models import (
     AnonUserState,
     get_and_update_user,
 )
 from .validators import is_mbi_format_valid, is_mbi_format_synthetic
-import logging
 from django.core.exceptions import ValidationError
 from rest_framework.exceptions import NotFound
 from django.views.decorators.cache import never_cache
@@ -24,7 +26,7 @@ from .signals import response_hook_wrapper
 from apps.dot_ext.models import Approval
 from apps.fhir.bluebutton.exceptions import UpstreamServerException
 from apps.fhir.bluebutton.models import hash_hicn, hash_mbi
-
+from apps.logging.serializers import SLSUserInfoResponse
 
 logger = logging.getLogger('hhs_server.%s' % __name__)
 authenticate_logger = logging.getLogger('audit.authenticate.sls')
@@ -39,7 +41,7 @@ def authenticate(request):
     sls_client = OAuth2Config()
 
     try:
-        sls_client.exchange(code)
+        sls_client.exchange(code, request)
     except requests.exceptions.HTTPError as e:
         logger.error("Token request response error {reason}".format(reason=e))
         raise UpstreamServerException('An error occurred connecting to account.mymedicare.gov')
@@ -50,11 +52,14 @@ def authenticate(request):
         'https://test.accounts.cms.gov/v1/oauth/userinfo')
 
     headers = sls_client.auth_header()
-    headers.update({"X-Request-ID": getattr(request, '__logging_uuid', None)})
+    # keep using deprecated conv - no conflict issue
+    headers.update({"X-SLS-starttime": str(datetime.datetime.utcnow())})
+    if request is not None:
+        headers.update({"X-Request-ID": str(getattr(request, '_logging_uuid', None) if hasattr(request, '_logging_uuid') else '')})
     response = requests.get(userinfo_endpoint,
                             headers=headers,
                             verify=sls_client.verify_ssl,
-                            hooks={'response': [response_hook_wrapper(sender='userinfo_endpoint')]})
+                            hooks={'response': [response_hook_wrapper(sender=SLSUserInfoResponse)]})
 
     try:
         response.raise_for_status()


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-190](https://jira.cms.gov/browse/BB2-190)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As BB2 developer, I need BB2 audit logger SLS_LOGGER (sls_logger = logging.getLogger('audit.authorization.sls')) to log SLS audit events: sls access token, sls userinfo, when they are returned from SLS, currently sls_logger fails to log due to SLSResponse instance throw 'Attribute Does not exist' exception on a non exist attibute 'path', so nothing is logged, also SLSResponse serializer does not include much info in the audit event.

Following changes need to be made on SLSResponse serializer to include key audit info from the SLS responses:

(1) For sls user_info endpoint, need to include endpoint path_url, sub, name, family name, email, hicn (hashed or masked), mbi (hashed or masked), among others in the event logged.

(2) For sls access token endpoint, need to include endpoint path_url, access_token, among others in the event logged.

(3) Catch any exception when create SLSResponse object, and emmit error stack as logging event when exception thrown during SLSResponse instantiation and serialization.

Note:

Number (3) is important to avoid scenarios as reported in BB2-134/BB2-135 where there is nothing in audit event and no info as where and why the error raised.

Same fix also applies to numerous other signal based loggers (in BB2 apps/logging/signals.py) and corresponding serializers (in BB2 apps/logging/serializers.py), as listed below:

token_logger = logging.getLogger('audit.authorization.token')
logged object (event): Token, DataAccessGrantSerializer

fhir_logger = logging.getLogger('audit.data.fhir')
logged object (event): FHIRequest, FHIRResponse

### What Does This PR Do?

<!--
Add detailed discussion of changes here
This is likely a summary, or the complete contents, of your commit messages.
-->

(1) Fix SLSResponse so that it will extract essential audit info when is response for SLS access token request (signal sender='token_endpoint') or SLS userinfo request (signal sender='userinfo_endpoint')
(2) Catch any exception during serialization of audit events (SLSResponse, Token, DataAccessGrantSerializer, FHIRequest, FHIRResponse) and log the exception stack when exception thrown.
(3) Make above serializers return json

Above changes will improve BB2 audit logging resiliency and facilitate debugging in case audit events serializers broken and throw exception.

### What Should Reviewers Watch For?

Before the fix, when SLS endpoints called, there is no event logged from the logger:
sls_logger = logging.getLogger('audit.authorization.sls')

After the fix, audit events like below are logged when SLS endpoints are called (e.g. during BB2 oauth2 flow):

sls access token event:

    audit.authorization.sls line:70 {"code": 200, "size": 100, "elapsed": 0.00379, "uuid": null, "user": null, "start_time": null, "application": null, "path": "/token", "type": "SLS_token", "access_token": "ZnJlZA.ZnJlZA.ZmxpbnQ.ZmxpbnQ.ZnJlZEBnbWFpbC5jb20.MTAwMDA0NDY4MA.MlNXNE4wMEFBMDA"}

sls userinfo event:

    audit.authorization.sls line:70 {"code": 200, "size": 137, "elapsed": 0.00187, "uuid": null, "user": null, "start_time": null, "application": null, "path": "/userinfo", "type": "SLS_userinfo", "sub": "fred", "name": "fred", "given_name": "flint", "family_name": "flint", "email": "fred@gmail.com", "hicn": "***********", "mbi": "***********"}


<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [ ] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.