### PR TITLE
jfuqian/BB2-220 Sandbox-App-Edit-Page-Not-Show-PhoneNumber

### DIFF
--- a/apps/dot_ext/tests/test_app_form_templates.py
+++ b/apps/dot_ext/tests/test_app_form_templates.py
@@ -1,0 +1,51 @@
+import uuid
+from django.test import TestCase
+from django.template import loader
+from django.template.base import VariableNode
+from apps.dot_ext.admin import CustomAdminApplicationForm
+
+
+def get_form_fields(frm):
+    '''
+    helper: extract all fields names from a form
+    '''
+    fields = list(frm().base_fields)
+    for field in list(frm().declared_fields):
+        if field not in fields:
+            fields.append(field)
+    return fields
+
+
+class AppFormTemplateTestCase(TestCase):
+    """
+    Test Application Form templates
+    Check: no dangling var reference in template html, vars are properly rendered with values
+    """
+    def check_template(self, frm, tmplt, ctx_prefix):
+        '''
+        helper: validate form <frm> against its template <tmplt> for dangling vars
+        '''
+        form_fields = get_form_fields(frm)
+        temp = loader.get_template(tmplt)
+        nodes = temp.template.nodelist.get_nodes_by_type(VariableNode)
+        prefix_len = len(ctx_prefix)
+        ref_fields = [n.token.contents[prefix_len + 1:] for n in nodes]
+        diff_flds = set(ref_fields) - set(form_fields)
+        self.assertTrue(set(ref_fields).issubset(set(form_fields)),
+                        "template {} referenced fields {} not in application context.".format(tmplt, diff_flds))
+        context = {
+            ctx_prefix: {f: uuid.uuid4().hex for f in ref_fields},
+        }
+        page_w_fld = temp.render(context)
+        # assert rendering values
+        ctx = context[ctx_prefix]
+        for k in ref_fields:
+            self.assertIn(ctx[k], page_w_fld, "Var [{}] value [{}] not found in rendered page.".format(k, ctx[k]))
+
+    def test_app_forms_templates(self):
+        """
+        Check vars in template html is consistent
+        with corresponding context (model)
+        """
+        self.check_template(CustomAdminApplicationForm, 'include/app-form-required-info.html', 'application')
+        self.check_template(CustomAdminApplicationForm, 'include/app-form-optional-info.html', 'application')

--- a/templates/include/app-form-optional-info.html
+++ b/templates/include/app-form-optional-info.html
@@ -60,7 +60,7 @@
 			  
 			<!-- App Support Phone Number -->
 			<label for="id_support_phone_number">Customer Support Phone Number</label>
-			<input type="text" name="support_phone_number" maxlength="17" id="id_support_phone_number" value="{{ application.support_phone }}">
+			<input type="text" name="support_phone_number" maxlength="17" id="id_support_phone_number" value="{{ application.support_phone_number }}">
 
 			<!-- App Contacts -->
 			<label for="id_contacts">App Development Team Contacts</label>


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-220](https://jira.cms.gov/browse/BB2-220)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As BB2 Developer Sandbox user (external app developer), I want to create (register) my applications with "Customer Support Phone Number" among other info such as terms and privacy policy etc., BB2 application edit page provide a field where a support phone number can be provided - typed in, however, after click "Save" the application registration form, and come back to application edit page, the "Customer Support Phone Number" field is blank.

Findings:

Debugging shows that BB2 model object Application has attribute "support_phone_number", however, the application edit page
template expects attribute "support_phone" as shown below:

BB2-SRC-BASE-DIR/templates/include/app-form-optional-info.html:

			<!-- App Support Phone Number -->
			<label for="id_support_phone_number">Customer Support Phone Number</label>
			<input type="text" name="support_phone_number" maxlength="17" id="id_support_phone" value="{{ application.support_phone }}">

### What Does This PR Do?

The issue can be fixed by changing the template as below:

			<!-- App Support Phone Number -->
			<label for="id_support_phone_number">Customer Support Phone Number</label>
			<input type="text" name="support_phone_number" maxlength="17" id="id_support_phone" value="{{ application.support_phone_number }}">


<!--
Add detailed discussion of changes here
This is likely a summary, or the complete contents, of your commit messages.
-->


### What Should Reviewers Watch For?

The fix can be verified by go to BB2 Developer Sandbox, create account and add applications with support phone numbers,
and logout and go back to the application edit page again, the field should show the phone number previously entered.

<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [ ] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.
