### PR TITLE
BB2-218 BB2-Fail-to-log-AccessToken-Revoke-AuditEvent

### DIFF
--- a/apps/fhir/bluebutton/tests/data_conformance.py
+++ b/apps/fhir/bluebutton/tests/data_conformance.py
@@ -3,7 +3,6 @@ hhs_oauth_server
 FILE: data_conformance
 Created: 7/19/16 6:37 PM
 
-<<<<<<< HEAD
 File created by: Mark Scirmshire @ekivemark
 
 """

--- a/apps/logging/signals.py
+++ b/apps/logging/signals.py
@@ -51,11 +51,13 @@ def handle_app_authorized(sender, request, user, application, **kwargs):
         },
     })
 
+
 # BB2-218 also capture delete MyAccessToken
 @receiver(post_delete, sender=MyAccessToken)
 @receiver(post_delete, sender=AccessToken)
 def token_removed(sender, instance=None, **kwargs):
     token_logger.info(Token(instance, action="revoked"))
+
 
 @receiver(post_delete, sender=DataAccessGrant)
 def log_grant_removed(sender, instance=None, **kwargs):

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -85,8 +85,7 @@ INSTALLED_APPS = [
     # DOT must be installed after apps.dot_ext in order to override templates
     'oauth2_provider',
     'axes',
-    # BB2-218 need to register LoggingConfig to get sls token signal handler registered
-    'apps.logging.LoggingConfig',
+    'apps.logging',
     'apps.openapi',
 ]
 if env('ENV_SPECIFIC_APPS', False):

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -85,8 +85,8 @@ INSTALLED_APPS = [
     # DOT must be installed after apps.dot_ext in order to override templates
     'oauth2_provider',
     'axes',
-
-    'apps.logging',
+    # BB2-218 need to register LoggingConfig to get sls token signal handler registered
+    'apps.logging.LoggingConfig',
     'apps.openapi',
 ]
 if env('ENV_SPECIFIC_APPS', False):

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -88,6 +88,7 @@ INSTALLED_APPS = [
     'apps.logging',
     'apps.openapi',
 ]
+
 if env('ENV_SPECIFIC_APPS', False):
     INSTALLED_APPS += env('ENV_SPECIFIC_APPS')
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-218](https://jira.cms.gov/browse/BB2-218)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a BB2 developer and administrator and analytical tools which consume audit events from BB2 logs, I expect an audit event: type:AccessToken, action:revoked logged whenever an access token is deleted through BB2 ADMIN UI.

ADMIN UI is used as BB2 token and grant manager, in BB2 ADMIN, there are THREE places you can revoke an access token:

(1) "Access Token" link under section "DJANGO OAUTH TOOLKIT", to go to "Access Token" manage page, to add, delete access token

(2) "My Access Token" link under section "BLUEBUTTON", to go to "My Access Token" manage page, to add, delete my access token

(3) "Data Access Grant" link under section "PROFILE", to go to "Data Access Grant" manage page, to add, delete data access grant - which associate user/app/access token.

 

Currently, below is a list of what works as expected, and what is not working as expected:

(1) Delete access token through path (1) as above works as expected, it logs one event "access token revoked"

(2) Delete data access grant through path (3) works as expected: it logs one event "access token revoked" and one event "data access grant revoked"

(3) Delete access token through path (2) does not work as expected, no event is logged.

  
### What Does This PR Do?

this PR fix the issue by adding another sender to listen to for access token post_delete signal  
`# BB2-218 also capture delete MyAccessToken

@receiver(post_delete, sender=MyAccessToken)

@receiver(post_delete, sender=AccessToken)

def token_removed(sender, instance=None, **kwargs):
    token_logger.info(Token(instance, action="revoked"))`

<!--
Add detailed discussion of changes here
This is likely a summary, or the complete contents, of your commit messages.
-->


### What Should Reviewers Watch For?

To verify that the issue is fixed, start BB2 instance (local dockerized BB2 for example), 
as instructed by readme.md.

Follow the steps as in [BB2-218](https://jira.cms.gov/browse/BB2-218)

Check server log, looking for events like shown below:

***ACCESS_TOKEN REVOKED EVENT:

audit.authorization.token line:54 audit.authorization.token line:54 {"type": "AccessToken", "action": "revoked", "id": 5, "access_token": "f327cf6da107507c0a51492a0e57357b2bcf6181e9e17d82ea493b6c47be3cd5", "application": { "id": 2,  "name": "TestApp",  "user": { "id": 4,  "username": "fred"} },"user": { "id": 4,  "username": "fred"}}

<!--
Add some items to the list above, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### Submitter Checklist

Before requesting final review, I've gone through and verified that this PR complies with the following requirements:

* [X] I've refactored and rebased this PR (for help, see: [this](https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had) and [this](https://raphaelfabeni.com/git-editing-commits-part-1/), if needed, so that it is as small as it can reasonably be, in order to:
    1. Ensure that any problems it causes have a small "blast radius".
    2. Ensure that it'll be easier to rollback if that becomes necessary.
    3. Ease the burden on reviewers.
* [X] I've verified that the commits in this PR:
    1. Reasonably explain the "what" and "why" of the changes.
    2. Leverage JIRA's [smart commits](https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html) to reference the JIRA ticket that they're associated with. For example, aim for commit messages like this (note also [the 50/72 formatting](https://stackoverflow.com/q/2290016) used here):
        
        ```
        Added the whizbang to the doodad.

        The new whizbang should really simplify things for our whoosit users.
        It was a bit tricky to get it into the doodad, but we decided that the
        flipwhee pattern was the best approach for now. Might want to revisit
        that in the future if it ends up being too hard to maintain.

        SOMEPROJECT-42
        ```
        
* [X] I've verified that this PR includes all required documentation changes, including `README` updates and changelog / release notes entries.
* [X] I've verified that all new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [ ] I've verified that all tech debt and/or shortcomings introduced by this PR is detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X] I've requested review from at least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
* [X] I've requested review from any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] I've verified that this PR and its changes comply with all other policies in the [DASG Engineering Standards](../policies/engineering_standards.md) and have specifically called out any/all deviations in this PR.
