### PR TITLE
BB2-264 Update P1 scopes to disable past access tokens

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -153,14 +153,24 @@ class SimpleAllowForm(DotAllowForm):
     code_challenge = forms.CharField(required=False, widget=forms.HiddenInput())
     code_challenge_method = forms.CharField(required=False, widget=forms.HiddenInput())
     auth_uuid = forms.CharField(required=False, widget=forms.HiddenInput())
-    block_personal_choice = forms.BooleanField(required=False)
+    share_demographic_scopes = forms.CharField(required=False)
 
     def clean(self):
         cleaned_data = super().clean()
-        scope = cleaned_data.get("scope")
+        scope = cleaned_data.get("scope", None)
 
-        # Remove personal information scopes, if requested by bene
-        if cleaned_data.get("block_personal_choice"):
+        if scope is None:
+            cleaned_data['scope'] = ""
+            scope = ""
+
+        # Default is True for any non "false" value.
+        if cleaned_data.get("share_demographic_scopes").lower() == "false":
+            share_demographic_scopes = False
+        else:
+            share_demographic_scopes = True
+
+        # Remove demographic information scopes, if beneficiary is not sharing
+        if not share_demographic_scopes:
             cleaned_data['scope'] = ' '.join([s for s in scope.split(" ")
                                              if s not in settings.BENE_PERSONAL_INFO_SCOPES])
 

--- a/apps/dot_ext/oauth2_backends.py
+++ b/apps/dot_ext/oauth2_backends.py
@@ -1,7 +1,6 @@
 import json
 from django.conf import settings
 from django.db import transaction
-from django.db.models import Q
 from oauth2_provider.oauth2_backends import OAuthLibCore
 from oauth2_provider.models import AccessToken, RefreshToken
 from ..fhir.bluebutton.models import Crosswalk
@@ -43,7 +42,7 @@ class OAuthLibSMARTonFHIR(OAuthLibCore):
             # Does new token scope NOT contain BENE_PERSONAL_INFO_SCOPES?
             if not set(settings.BENE_PERSONAL_INFO_SCOPES).issubset(scope.split()):
                 with transaction.atomic():
-                    AccessToken.objects.filter(application=app, user=user).filter(~Q(id=token.id)).delete()
-                    RefreshToken.objects.filter(application=app, user=user).filter(~Q(access_token=token)).delete()
+                    AccessToken.objects.filter(application=app, user=user).exclude(id=token.id).delete()
+                    RefreshToken.objects.filter(application=app, user=user).exclude(access_token=token).delete()
 
         return uri, headers, body, status

--- a/apps/dot_ext/oauth2_backends.py
+++ b/apps/dot_ext/oauth2_backends.py
@@ -1,6 +1,7 @@
 import json
 from django.conf import settings
 from django.db import transaction
+from django.db.models import Q
 from oauth2_provider.oauth2_backends import OAuthLibCore
 from oauth2_provider.models import AccessToken, RefreshToken
 from ..fhir.bluebutton.models import Crosswalk
@@ -42,14 +43,7 @@ class OAuthLibSMARTonFHIR(OAuthLibCore):
             # Does new token scope NOT contain BENE_PERSONAL_INFO_SCOPES?
             if not set(settings.BENE_PERSONAL_INFO_SCOPES).issubset(scope.split()):
                 with transaction.atomic():
-                    # Loop thru all AC's for app/user pair.
-                    for tkn in AccessToken.objects.filter(application=app, user=user):
-                        # If not the new token, delete.
-                        if tkn != token:
-                            # Delete related refresh tokens.
-                            for refresh_tkn in RefreshToken.objects.filter(access_token=tkn):
-                                refresh_tkn.delete()
-                            # Delete past token.
-                            tkn.delete()
+                    AccessToken.objects.filter(application=app, user=user).filter(~Q(id=token.id)).delete()
+                    RefreshToken.objects.filter(application=app, user=user).filter(~Q(access_token=token)).delete()
 
         return uri, headers, body, status

--- a/apps/dot_ext/tests/test_beneficiary_demographic_scope_changes.py
+++ b/apps/dot_ext/tests/test_beneficiary_demographic_scope_changes.py
@@ -2,7 +2,7 @@ import json
 from apps.test import BaseApiTest
 from django.urls import reverse
 from oauth2_provider.compat import parse_qs, urlparse
-from oauth2_provider.models import AccessToken
+from oauth2_provider.models import AccessToken, RefreshToken
 from rest_framework.test import APIClient
 from waffle.testutils import override_switch
 from ..models import Application
@@ -139,6 +139,12 @@ class TestBeneficiaryDemographicScopesChanges(BaseApiTest):
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 200)
 
+        # Verify token counts expected.
+        access_token_count = AccessToken.objects.count()
+        refresh_token_count = RefreshToken.objects.count()
+        self.assertEqual(access_token_count, 2)
+        self.assertEqual(refresh_token_count, 2)
+
         # ------ TEST #3:  3nd authorization: Beneficary authorizes NOT to share demographic data. ------
         payload['share_demographic_scopes'] = False
 
@@ -165,6 +171,12 @@ class TestBeneficiaryDemographicScopesChanges(BaseApiTest):
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(content.get('detail', None), "You do not have permission to perform this action.")
+
+        # Verify token counts expected.
+        access_token_count = AccessToken.objects.count()
+        refresh_token_count = RefreshToken.objects.count()
+        self.assertEqual(access_token_count, 1)
+        self.assertEqual(refresh_token_count, 1)
 
         # ------ TEST #4:  Test token_1 from TEST #1 access to userinfo? Does it still have access? ------
         # Setup token in APIClient
@@ -226,3 +238,9 @@ class TestBeneficiaryDemographicScopesChanges(BaseApiTest):
         content = json.loads(response.content)
         self.assertEqual(response.status_code, 403)
         self.assertEqual(content.get('detail', None), "You do not have permission to perform this action.")
+
+        # Verify token counts expected.
+        access_token_count = AccessToken.objects.count()
+        refresh_token_count = RefreshToken.objects.count()
+        self.assertEqual(access_token_count, 2)
+        self.assertEqual(refresh_token_count, 2)

--- a/apps/dot_ext/tests/test_beneficiary_demographic_scope_changes.py
+++ b/apps/dot_ext/tests/test_beneficiary_demographic_scope_changes.py
@@ -1,0 +1,228 @@
+import json
+from apps.test import BaseApiTest
+from django.urls import reverse
+from oauth2_provider.compat import parse_qs, urlparse
+from oauth2_provider.models import AccessToken
+from rest_framework.test import APIClient
+from waffle.testutils import override_switch
+from ..models import Application
+
+
+class TestBeneficiaryDemographicScopesChanges(BaseApiTest):
+    fixtures = ['scopes.json']
+
+    @override_switch('require-scopes', active=True)
+    def _authorize_and_request_token(self, payload, application):
+        response = self.client.post(reverse('oauth2_provider:authorize'), data=payload)
+        self.assertEqual(response.status_code, 302)
+        # now extract the authorization code and use it to request an access_token
+        query_dict = parse_qs(urlparse(response['Location']).query)
+        authorization_code = query_dict.pop('code')
+        token_request_data = {
+            'grant_type': 'authorization_code',
+            'code': authorization_code,
+            'redirect_uri': 'http://example.it',
+            'client_id': application.client_id,
+        }
+        return self.client.post(reverse('oauth2_provider:token'), data=token_request_data)
+
+    def _assertScopeResponse(self, scope, scopes_granted_access_token, response, content):
+        # Assert expected response and content for scope vs. what is granted.
+        if scope in scopes_granted_access_token:
+            # Path is allowed by scopes.
+            self.assertEqual(response.status_code, 200)
+        else:
+            # Path is NOT allowed by scopes.
+            self.assertEqual(response.status_code, 403)
+
+    @override_switch('require-scopes', active=True)
+    def test_bene_demo_scopes_change(self):
+        """
+        Test authorization related to different, beneficiary "share_demographic_scopes"
+        choices made on subsequent authorizations.
+
+        Test that previous access/refresh tokens are updated related to the
+        beneficiary's sharing choice. Tokens should be deleted when the choices is to
+        NOT share demographic scopes.
+        """
+        # create a user
+        self._create_user('anna', '123456')
+
+        # create an application and add some extra capabilities
+        application = self._create_application(
+            'an app', grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            redirect_uris='http://example.it')
+
+        # Give the app some additional scopes.
+        capability_a = self._create_capability('Capability A', [])
+        capability_b = self._create_capability('Capability B', [])
+        application.scope.add(capability_a, capability_b)
+
+        # user logs in
+        self.client.login(username='anna', password='123456')
+
+        # Scopes lists for testing
+        APPLICATION_SCOPES_FULL = ['patient/Patient.read', 'profile',
+                                   'patient/ExplanationOfBenefit.read', 'patient/Coverage.read',
+                                   'capability-a', 'capability-b']
+        APPLICATION_SCOPES_NON_DEMOGRAPHIC = ['patient/ExplanationOfBenefit.read',
+                                              'patient/Coverage.read', 'capability-a', 'capability-b']
+
+        # Setup request parameters for test case
+        request_scopes = APPLICATION_SCOPES_FULL
+
+        # Init API client for request calls
+        client = APIClient()
+
+        payload = {'client_id': application.client_id,
+                   'response_type': 'code',
+                   'redirect_uri': 'http://example.it',
+                   'expires_in': 86400,
+                   'allow': True}
+
+        request_scopes = APPLICATION_SCOPES_FULL
+        # Scopes to be requested in the authorization request
+        payload['scope'] = ' '.join(request_scopes)
+
+        # ------ TEST #1: 1st authorization: Beneficary authorizes to share demographic data. ------
+        payload['share_demographic_scopes'] = True
+
+        # Perform authorization request
+        response = self._authorize_and_request_token(payload, application)
+
+        # Assert auth request was successful
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content.decode("utf-8"))
+
+        # Test scope in response content
+        self.assertEqual(sorted(content['scope'].split()), sorted(APPLICATION_SCOPES_FULL))
+
+        # Test scope in access_token
+        token_1 = AccessToken.objects.get(token=content['access_token'])
+        refresh_token_1 = content['refresh_token']
+
+        scopes_granted_access_token = sorted(token_1.scope.split())
+        self.assertEqual(scopes_granted_access_token, sorted(APPLICATION_SCOPES_FULL))
+
+        # Setup token_1 in APIClient
+        client.credentials(HTTP_AUTHORIZATION="Bearer " + token_1.token)
+
+        # Test access to userinfo end point?
+        response = client.get("/v1/connect/userinfo")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+
+        # ------ TEST #2: SAME authorization: Beneficary authorizes to share FULL demographic data. ------
+        payload['share_demographic_scopes'] = True
+
+        # Perform authorization request
+        response = self._authorize_and_request_token(payload, application)
+
+        # Assert auth request was successful
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content.decode("utf-8"))
+
+        # Test scope in response content
+        self.assertEqual(sorted(content['scope'].split()), sorted(APPLICATION_SCOPES_FULL))
+
+        # Test scope in access_token
+        token_2 = AccessToken.objects.get(token=content['access_token'])
+
+        scopes_granted_access_token = sorted(token_2.scope.split())
+        self.assertEqual(scopes_granted_access_token, sorted(APPLICATION_SCOPES_FULL))
+
+        # Setup token_2 in APIClient
+        client.credentials(HTTP_AUTHORIZATION="Bearer " + token_2.token)
+
+        # Test access to userinfo end point?
+        response = client.get("/v1/connect/userinfo")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+
+        # ------ TEST #3:  3nd authorization: Beneficary authorizes NOT to share demographic data. ------
+        payload['share_demographic_scopes'] = False
+
+        # Perform authorization request
+        response = self._authorize_and_request_token(payload, application)
+
+        # Assert auth request was successful
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content.decode("utf-8"))
+
+        # Test scope in response content
+        self.assertEqual(sorted(content['scope'].split()), sorted(APPLICATION_SCOPES_NON_DEMOGRAPHIC))
+
+        # Test scope in access_token
+        token_3 = AccessToken.objects.get(token=content['access_token'])
+        scopes_granted_access_token = sorted(token_3.scope.split())
+        self.assertEqual(scopes_granted_access_token, sorted(APPLICATION_SCOPES_NON_DEMOGRAPHIC))
+
+        # Setup token_3 in APIClient
+        client.credentials(HTTP_AUTHORIZATION="Bearer " + token_3.token)
+
+        # Test access to userinfo end point? NO PERMISSION!
+        response = client.get("/v1/connect/userinfo")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(content.get('detail', None), "You do not have permission to perform this action.")
+
+        # ------ TEST #4:  Test token_1 from TEST #1 access to userinfo? Does it still have access? ------
+        # Setup token in APIClient
+        client.credentials(HTTP_AUTHORIZATION="Bearer " + token_1.token)
+
+        # Test access to userinfo end point? NO ACCESS!
+        response = client.get("/v1/connect/userinfo")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(content.get('detail', None), "Authentication credentials were not provided.")
+
+        # ------ TEST #5:  Test token_1 from TEST #1 token refresh? NO ACCESS!
+        refresh_request_data = {
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_token_1,
+            'redirect_uri': 'http://example.it',
+            'client_id': application.client_id,
+            'client_secret': application.client_secret,
+        }
+        response = self.client.post(reverse('oauth2_provider:token'), data=refresh_request_data)
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(content.get('error', None), "invalid_grant")
+
+        # ------ TEST #6: Beneficary authorizes to share FULL demographic data again.. ------
+        payload['share_demographic_scopes'] = True
+
+        # Perform authorization request
+        response = self._authorize_and_request_token(payload, application)
+
+        # Assert auth request was successful
+        self.assertEqual(response.status_code, 200)
+        content = json.loads(response.content.decode("utf-8"))
+
+        # Test scope in response content
+        self.assertEqual(sorted(content['scope'].split()), sorted(APPLICATION_SCOPES_FULL))
+
+        # Test scope in access_token
+        token_6 = AccessToken.objects.get(token=content['access_token'])
+
+        scopes_granted_access_token = sorted(token_6.scope.split())
+        self.assertEqual(scopes_granted_access_token, sorted(APPLICATION_SCOPES_FULL))
+
+        # Setup token_6 in APIClient
+        client.credentials(HTTP_AUTHORIZATION="Bearer " + token_6.token)
+
+        # Test access to userinfo end point?
+        response = client.get("/v1/connect/userinfo")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 200)
+
+        # ------ TEST #7: Test token_3 from TEST #3 again. It should still have access, but no permission with status=403.
+
+        # Setup token_3 in APIClient from previous step.
+        client.credentials(HTTP_AUTHORIZATION="Bearer " + token_3.token)
+
+        # Test access to userinfo end point?
+        response = client.get("/v1/connect/userinfo")
+        content = json.loads(response.content)
+        self.assertEqual(response.status_code, 403)
+        self.assertEqual(content.get('detail', None), "You do not have permission to perform this action.")

--- a/apps/dot_ext/tests/test_form_oauth2.py
+++ b/apps/dot_ext/tests/test_form_oauth2.py
@@ -9,7 +9,7 @@ class TestSimpleAllowFormForm(BaseApiTest):
 
     def test_form(self):
         """
-            Test form related to scopes and BENE block_personal_choice.
+        Test form related to scopes and BENE share_demographic_scopes.
         """
         full_scopes_list = CapabilitiesScopes().get_default_scopes()
         non_personal_scopes_list = list(set(full_scopes_list) - set(settings.BENE_PERSONAL_INFO_SCOPES))
@@ -23,9 +23,10 @@ class TestSimpleAllowFormForm(BaseApiTest):
                 'code_challenge_method': '',
                 'allow': 'Allow'}
 
-        # 1. Test with block_personal_choice = False
+        # 1. Test with share_demographic_scopes = True
         #        Should have full scopes list.
-        data['block_personal_choice'] = 'False'
+        data['share_demographic_scopes'] = 'True'
+
         form = SimpleAllowForm(data)
         self.assertTrue(form.is_valid())
         cleaned_data = form.cleaned_data
@@ -34,9 +35,20 @@ class TestSimpleAllowFormForm(BaseApiTest):
         self.assertEqual(sorted(full_scopes_list),
                          sorted(cleaned_data['scope'].split()))
 
-        # 2. Test with block_personal_choice = True
+        # 2. Test with share_demographic_scopes = None (missing/empty)
+        #        Should have full scopes list.
+        del data['share_demographic_scopes']
+        form = SimpleAllowForm(data)
+        self.assertTrue(form.is_valid())
+        cleaned_data = form.cleaned_data
+
+        self.assertNotEqual(cleaned_data['scope'].split(), None)
+        self.assertEqual(sorted(full_scopes_list),
+                         sorted(cleaned_data['scope'].split()))
+
+        # 3. Test with share_demographic_scopes = False
         #        Should have non personal scopes list.
-        data['block_personal_choice'] = 'True'
+        data['share_demographic_scopes'] = 'False'
         form = SimpleAllowForm(data)
         self.assertTrue(form.is_valid())
         cleaned_data = form.cleaned_data

--- a/apps/dot_ext/tests/test_views.py
+++ b/apps/dot_ext/tests/test_views.py
@@ -81,9 +81,9 @@ class TestAuthorizationView(BaseApiTest):
         # and here we test that only the capability-a scope has been issued
         self.assertEqual(content['scope'], "capability-a")
 
-    def test_post_with_block_personal_choice(self):
+    def test_post_with_share_demographic_scopes(self):
         """
-        Test that when user chooses the block_personal_choice on
+        Test that when user chooses the share_demographic_scopes on
         the BENE consent form, that the correct scopes are blocked
         with the require-scopes feature switch DISABLED.
         """
@@ -113,23 +113,23 @@ class TestAuthorizationView(BaseApiTest):
             'allow': True,
         }
 
-        # 1. Test the authorization with block_personal_choice = None.
+        # 1. Test the authorization with share_demographic_scopes = None.
         response = self._authorize_and_request_token(payload, application)
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content.decode("utf-8"))
         # and here we test that the full scopes have been issued
         self.assertEqual(sorted(content['scope'].split()), sorted(full_scopes_list))
 
-        # 2. Test the authorization with block_personal_choice = False.
-        payload['block_personal_choice'] = 'False'
+        # 2. Test the authorization with share_demographic_scopes = True.
+        payload['share_demographic_scopes'] = 'True'
         response = self._authorize_and_request_token(payload, application)
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content.decode("utf-8"))
         # and here we test that the full scopes have been issued
         self.assertEqual(sorted(content['scope'].split()), sorted(full_scopes_list))
 
-        # 3. Test the authorization with block_personal_choice = True.
-        payload['block_personal_choice'] = 'True'
+        # 3. Test the authorization with share_demographic_scopes = False.
+        payload['share_demographic_scopes'] = 'False'
         response = self._authorize_and_request_token(payload, application)
         self.assertEqual(response.status_code, 200)
         content = json.loads(response.content.decode("utf-8"))

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -66,6 +66,7 @@ class AuthorizationView(DotAuthorizationView):
         }
         scopes = form.cleaned_data.get("scope")
         allow = form.cleaned_data.get("allow")
+        share_demographic_scopes = form.cleaned_data.get("share_demographic_scopes")
 
         try:
             uri, headers, body, status = self.create_authorization_response(
@@ -78,7 +79,9 @@ class AuthorizationView(DotAuthorizationView):
             sender=self,
             request=self.request,
             user=self.request.user,
-            application=application)
+            application=application,
+            share_demographic_scopes=share_demographic_scopes,
+            scopes=scopes)
 
         self.success_url = uri
         log.debug("Success url for the request: {0}".format(self.success_url))

--- a/apps/logging/serializers.py
+++ b/apps/logging/serializers.py
@@ -53,6 +53,14 @@ class Token:
         app = getattr(self.tkn, 'application', None)
         app_user = getattr(app, 'user', None)
         user = getattr(self.tkn, 'user', None)
+        scopes_dict = getattr(self.tkn, 'scopes', None)
+
+        if scopes_dict:
+            # Convert dict keys list to str
+            scopes = " ".join(scopes_dict.keys())
+        else:
+            scopes = ""
+
         result = {
             "type": "AccessToken",
             "auth_uuid": self.auth_flow_dict.get('auth_uuid', None),
@@ -64,6 +72,7 @@ class Token:
             "id": getattr(self.tkn, 'pk', None),
             "access_token": hashlib.sha256(
                 str(getattr(self.tkn, 'token', None)).encode('utf-8')).hexdigest(),
+            "scopes": scopes,
             "application": {
                 "id": getattr(app, 'id', None),
                 "name": getattr(app, 'name', None),

--- a/apps/logging/signals.py
+++ b/apps/logging/signals.py
@@ -41,19 +41,21 @@ def handle_token_created(sender, request, token, **kwargs):
 
 
 @receiver(beneficiary_authorized_application)
-def handle_app_authorized(sender, request, user, application,
-                          share_demographic_scopes, scopes, **kwargs):
+def handle_app_authorized(sender, request, auth_status, auth_status_code, user, application,
+                          share_demographic_scopes, scopes, allow, **kwargs):
 
     # Get auth flow dict from session for logging
     auth_flow_dict = get_session_auth_flow_trace(request)
 
-    token_logger.info(json.dumps({
+    token_logger.info(get_event(json.dumps({
         "type": "Authorization",
         "auth_uuid": auth_flow_dict.get('auth_uuid', None),
         "auth_app_id": auth_flow_dict.get('auth_app_id', None),
         "auth_app_name": auth_flow_dict.get('auth_app_name', None),
         "auth_client_id": auth_flow_dict.get('auth_client_id', None),
         "auth_pkce_method": auth_flow_dict.get('auth_pkce_method', None),
+        "auth_status": auth_status,
+        "auth_status_code": auth_status_code,
         "user": {
             "id": user.id,
             "username": user.username,
@@ -71,7 +73,8 @@ def handle_app_authorized(sender, request, user, application,
         },
         "share_demographic_scopes": share_demographic_scopes,
         "scopes": scopes,
-    }))
+        "allow": allow,
+    })))
 
 
 # BB2-218 also capture delete MyAccessToken

--- a/apps/logging/signals.py
+++ b/apps/logging/signals.py
@@ -41,7 +41,9 @@ def handle_token_created(sender, request, token, **kwargs):
 
 
 @receiver(beneficiary_authorized_application)
-def handle_app_authorized(sender, request, user, application, **kwargs):
+def handle_app_authorized(sender, request, user, application,
+                          share_demographic_scopes, scopes, **kwargs):
+
     # Get auth flow dict from session for logging
     auth_flow_dict = get_session_auth_flow_trace(request)
 
@@ -67,6 +69,8 @@ def handle_app_authorized(sender, request, user, application, **kwargs):
             "id": application.id,
             "name": application.name,
         },
+        "share_demographic_scopes": share_demographic_scopes,
+        "scopes": scopes,
     }))
 
 

--- a/templates/design_system/authorize_v2.html
+++ b/templates/design_system/authorize_v2.html
@@ -27,28 +27,33 @@
 		<h1 class="ds-u-font-size--h2">{{ application.name }} has asked for some of your data.</h1>
 
 		<ul>
-			<li>Information about your doctor/hosiptal visits</li>
+			<li>Information about your doctor/hospital visits</li>
 			<li>Information about the prescription medications you take</li>
-			<li>Personal Information like your name, address, date of birth, race, and gender</li>
+			{% if application.require_demographic_scopes != False %}
+				<li>Personal Information like your name, address, date of birth, race, and gender</li>
+			{% endif %}
+
 		</ul>
 
 		{% if not error %}
 		<form id="authorizationForm" method="post">
-			<fieldset class="ds-c-fieldset bene-auth-fieldset">
-				<legend class="ds-c-label">
-					<h2 class="ds-u-font-size--h3">Privacy Options</h2>
-				</legend>
-				<input class="ds-c-choice" id="radio-1" type="radio" name="block_personal_choice" value="False" checked />
-				<label for="radio-1">
-					<span class="ds-u-font-size--lead">Share all of your data</span>
-					<span class="ds-c-field__hint">This app will have access to both your healthcare data and some personal information</span>
-				</label>
-				<input class="ds-c-choice" id="radio-2" type="radio" name="block_personal_choice" value="True"/>
-				<label for="radio-2">
-					<span class="ds-u-font-size--lead">Share healthcare data, but not your personal info</span>
-					<span class="ds-c-field__hint">Block some of your personal data like name, address, date of birth, race, and gender</span>
-				</label>
-			</fieldset>
+			{% if application.require_demographic_scopes != False %}
+				<fieldset class="ds-c-fieldset bene-auth-fieldset">
+					<legend class="ds-c-label">
+						<h2 class="ds-u-font-size--h3">Privacy Options</h2>
+					</legend>
+					<input class="ds-c-choice" id="radio-1" type="radio" name="share_demographic_scopes" value="True" checked />
+					<label for="radio-1">
+						<span class="ds-u-font-size--lead">Share all of your data</span>
+						<span class="ds-c-field__hint">This app will have access to both your healthcare data and some personal information</span>
+					</label>
+					<input class="ds-c-choice" id="radio-2" type="radio" name="share_demographic_scopes" value="False"/>
+					<label for="radio-2">
+						<span class="ds-u-font-size--lead">Share healthcare data, but not your personal info</span>
+						<span class="ds-c-field__hint">Block some of your personal data like name, address, date of birth, race, and gender</span>
+					</label>
+				</fieldset>
+			{% endif %}
 
                         {% csrf_token %}
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-264](https://jira.cms.gov/browse/BB2-264)


**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
As a team, we need to disable past access tokens to ensure that new user preferences against phase 1 scopes are recognized. 

This PR adds the following:
  - Past access and refresh tokens are disabled when a beneficiary has chosen not to share demographic data. 
  - Logging is added against user preference updates regarding demographic data sharing. 
  - Unit testing is created to test access and refresh token behaviors. 


This PR adds improvements to previous work done for [BLUEBUTTON-1647](https://jira.cms.gov/browse/BLUEBUTTON-1647). BLUEBUTTON-1647 Demographic filter scopes phase1 #788


### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->

Notes from the commit history:



* Add missing tests for switch `require-scopes=False`
  - Add `TestTokenHasProtectedCapabilityScopesSwitchFalse` tests for the require-scopes waffle feature switch set to False in apps/capabilities/tests.py

* Refactor field name and logic for bene scopes
  - Rename form `field block_personal_choice` to `share_demographic_scopes` for logic readability preparing for BB2-181 changes. Note that the logic is now reversed. The setting of `block_personal_scopes=True` is equivilant to `share_demographic_scopes=False`. This is to make the code logic easier to read. Especially related to the upcoming BB2-181 PR!
  - Update scopes logic in SimpleAllowForm in apps/dot_ext/forms.py  related to field name/logic change.
  - Update apps/dot_ext/tests/test_views.py related to name/logic change.
  - apps/dot_ext/tests/test_form_oauth2.py related to name/logic change.
  - Checkout templates/design_system/authorize_v2.html from BB2-181 branch related to name/logic change.

* Add scopes and bene scopes sharing choice to logs
  - Add `share_demographic_scopes` and scopes to the beneficiary_authorized_application signal handler.
  - Add scopes to the `AccessToken serializer` for logging.

* Add additional info to audit logging
  - Add beneficiary `allow` choice, `auth_status`, and `auth_status_code` to apps.logging.signals.handle_app_authorized() signal handler for logging.
  - Add `auth_status` message of "FAIL" and auth_status_code to log related to the error_response return in AuthorizationView.form_valid()

* Update cleanup for BEN does NOT share demo scopes
  - Update OAuthLibSMARTonFHIR.create_token_response() for token cleanup in apps/dot_ext/oauth2_backends.py.  On a successful token response where status=200 clean up past access/refresh tokens when a beneficiary chooses NOT to share demographic scopes.  This ensures past tokens and refresh tokens that had the FULL demographic scopes can not be used.
  - Create unit tests for different combinations of bene demographic scopes choices in apps.dot_ext.tests.test_beneficiary_demographic_scope_changes.py


### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check these things, in particular:

* Are there any unhandled and/or untested edge cases you can think of?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
* Naming in general? Do the namings of variables, methods, classes, and other items make sense? Are they too verbose, or not verbose enough? Any redundancies? Are the comments descriptive enough?
* Are audit logging items properly handled? Is sensitive information either not included or hashed?


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
    * Does this PR add any new software dependencies?  **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **Yes** or **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->


### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [ X] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [ X] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
* [X ] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [X ] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [X ] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [X ] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [X ] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.

