### PR TITLE
BB2-245-enable-ssl-server-cert-verify-for-all-bb2-to-bfd-requests.

### DIFF
--- a/apps/dot_ext/tests/test_views.py
+++ b/apps/dot_ext/tests/test_views.py
@@ -221,6 +221,7 @@ class TestTokenView(BaseApiTest):
         self.assertEqual(result, expected)
 
     def test_delete_token_success(self):
+        error_msg_regex = 'Could not find the TLS certificate file.*|Could not find a suitable TLS CA certificate bundle.*'
         anna = self._create_user(self.test_username, '123456', fhir_id='19990000000002')
         bob = self._create_user('bob',
                                 '123456',
@@ -250,7 +251,7 @@ class TestTokenView(BaseApiTest):
 
         # Post Django 2.2:  An OSError exception is expected when trying to reach the
         #                   backend FHIR server and proves authentication worked.
-        with self.assertRaisesRegexp(OSError, "Could not find the TLS certificate file"):
+        with self.assertRaisesRegexp(OSError, error_msg_regex):
             response = self.client.get('/v1/fhir/Patient',
                                        HTTP_AUTHORIZATION="Bearer " + tkn.token)
 
@@ -287,7 +288,7 @@ class TestTokenView(BaseApiTest):
 
         # Post Django 2.2:  An OSError exception is expected when trying to reach the
         #                   backend FHIR server and proves authentication worked.
-        with self.assertRaisesRegexp(OSError, "Could not find the TLS certificate file"):
+        with self.assertRaisesRegexp(OSError, error_msg_regex):
             response = self.client.get('/v1/fhir/Patient',
                                        HTTP_AUTHORIZATION="Bearer " + bob_tkn.token)
 
@@ -295,7 +296,7 @@ class TestTokenView(BaseApiTest):
 
         # Post Django 2.2:  An OSError exception is expected when trying to reach the
         #                   backend FHIR server and proves authentication worked.
-        with self.assertRaisesRegexp(OSError, "Could not find the TLS certificate file"):
+        with self.assertRaisesRegexp(OSError, error_msg_regex):
             response = self.client.get('/v1/fhir/Patient',
                                        HTTP_AUTHORIZATION="Bearer " + next_tkn.token)
 

--- a/apps/fhir/bluebutton/views/generic.py
+++ b/apps/fhir/bluebutton/views/generic.py
@@ -110,11 +110,13 @@ class FhirDataView(APIView):
         prepped = s.prepare_request(req)
         # Send signal
         pre_fetch.send_robust(FhirDataView, request=req)
+        verify_server = FhirServerVerify(crosswalk=request.crosswalk)
+        verify_server = resource_router.ca_bundle if verify_server else False
         r = s.send(
             prepped,
             cert=backend_connection.certs(crosswalk=request.crosswalk),
             timeout=resource_router.wait_time,
-            verify=FhirServerVerify(crosswalk=request.crosswalk))
+            verify=verify_server)
         # Send signal
         post_fetch.send_robust(FhirDataView, request=prepped, response=r)
         response = build_fhir_response(request._request, target_url, request.crosswalk, r=r, e=None)

--- a/apps/fhir/server/authentication.py
+++ b/apps/fhir/server/authentication.py
@@ -63,8 +63,9 @@ def search_fhir_id_by_identifier(search_identifier, request=None):
         headers = None
         auth_flow_dict = None
 
+    resource_router = get_resourcerouter()
     # Build URL with patient ID search by identifier.
-    url = get_resourcerouter().fhir_url \
+    url = resource_router.fhir_url \
         + "Patient/?identifier=" + search_identifier \
         + "&_format=" + settings.FHIR_PARAM_FORMAT
 
@@ -73,7 +74,7 @@ def search_fhir_id_by_identifier(search_identifier, request=None):
     req = requests.Request('GET', url, headers=headers)
     prepped = req.prepare()
     pre_fetch.send_robust(FhirServerAuth, request=req, auth_flow_dict=auth_flow_dict)
-    response = s.send(prepped, cert=certs, verify=False)
+    response = s.send(prepped, cert=certs, verify=resource_router.ca_bundle if resource_router.verify_server else False)
     post_fetch.send_robust(FhirServerAuth, request=req, response=response, auth_flow_dict=auth_flow_dict)
     response.raise_for_status()
     backend_data = response.json()

--- a/apps/fhir/server/settings.py
+++ b/apps/fhir/server/settings.py
@@ -22,6 +22,7 @@ DEFAULTS = {
     "SERVER_VERIFY": False,
     "WAIT_TIME": 30,
     "VERIFY_SERVER": False,
+    "CA_BUNDLE": None,
 }
 
 # List of settings that cannot be empty

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -376,8 +376,7 @@ DEFAULT_DISCLOSURE_TEXT = """
 
 DISCLOSURE_TEXT = env('DJANGO_PRIVACY_POLICY_URI', DEFAULT_DISCLOSURE_TEXT)
 
-#HOSTNAME_URL = env('HOSTNAME_URL', 'http://localhost:8000')
-HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.109:8000')
+HOSTNAME_URL = env('HOSTNAME_URL', 'http://localhost:8000')
 
 # Set the default Encoding standard. typically 'utf-8'
 ENCODING = 'utf-8'

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -376,7 +376,8 @@ DEFAULT_DISCLOSURE_TEXT = """
 
 DISCLOSURE_TEXT = env('DJANGO_PRIVACY_POLICY_URI', DEFAULT_DISCLOSURE_TEXT)
 
-HOSTNAME_URL = env('HOSTNAME_URL', 'http://localhost:8000')
+#HOSTNAME_URL = env('HOSTNAME_URL', 'http://localhost:8000')
+HOSTNAME_URL = env('HOSTNAME_URL', 'http://192.168.0.109:8000')
 
 # Set the default Encoding standard. typically 'utf-8'
 ENCODING = 'utf-8'
@@ -417,11 +418,17 @@ SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 FHIR_CLIENT_CERTSTORE = env('DJANGO_FHIR_CERTSTORE',
                             os.path.join(BASE_DIR, env('DJANGO_FHIR_CERTSTORE_REL', '../certstore')))
 
+# BB2-245 do ssl verify when access BFD services
+# Added Blue Button trusted store - a directory where CA certs (for production) / self-signed certs (for dev/test)
+# are stored, default to a sub directory 'trusted_certs' under FHIR_CLIENT_CERTSTORE
+# Added flag verify_ssl, default to True
 FHIR_SERVER = {
     "FHIR_URL": env("FHIR_URL", "https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/"),
     "CERT_FILE": os.path.join(FHIR_CLIENT_CERTSTORE, env("FHIR_CERT_FILE", "ca.cert.pem")),
     "KEY_FILE": os.path.join(FHIR_CLIENT_CERTSTORE, env("FHIR_KEY_FILE", "ca.key.nocrypt.pem")),
+    "CA_BUNDLE": os.path.join(FHIR_CLIENT_CERTSTORE, env("CA_BUNDLE", "ca_bundle.pem")),
     "CLIENT_AUTH": True,
+    "VERIFY_SERVER": True,
 }
 
 '''


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-245](https://jira.cms.gov/browse/BB2-245)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
To prevent man-in-the-middle attack (MITM), it is highly desirable to ensure that, where BB2 call BFD, that SSL server verify is enabled in order to ensure a secure communication with the BFD. it is desirable to make it a configurable e.g. in BB2 settings, such that when doing development the setup burden can be avoided.
 
By default, FHIR_SERVER->VERIFY_SERVER set to True as shown below by excerpt from BB2 configuration settings in hhs_base.py 
 
`FHIR_SERVER = {
    "FHIR_URL": env("FHIR_URL", "https://fhir.backend.bluebutton.hhsdevcloud.us/v1/fhir/"),
    "CERT_FILE": os.path.join(FHIR_CLIENT_CERTSTORE, env("FHIR_CERT_FILE", "ca.cert.pem")),
    "KEY_FILE": os.path.join(FHIR_CLIENT_CERTSTORE, env("FHIR_KEY_FILE", "ca.key.nocrypt.pem")),
    "CA_BUNDLE": os.path.join(FHIR_CLIENT_CERTSTORE, env("CA_BUNDLE", "ca_bundle.pem")),
    "CLIENT_AUTH": True,
    "VERIFY_SERVER": True,
}`

Note, when FHIR_SERVER->VERIFY_SERVER set to True, CA_BUNDLE has to be provided, which is a path pointing to trusted server SSL certificate.

A/C: 

1. BB2 configuration parameters are present which can be set to enable BB2 to do SSL server verify when communicte 
to BFD 
 2. When properly configured, i.e. FHIR_SERVER->VERIFY_SERVER set to True (default), and a valid server certificate located at the path as given by BB2 settings parameter CA_BUNDLE, than BB2 will perform server verify when communicate with BFD
3. When VERIFY_SERVER is False, BB2 will not perform SSL server verify when communicate with BFD (less secure, vulnerable to MITM)

Notes: 

Here is an example call where we want to have verify=True
In apps.fhir.server.authentication.py:
`response = requests.get(url, cert=certs, verify=False)
response.raise_for_status()
backend_data = response.json()
`
Currently there are two locations where BB2 call BFD, 

1. In authorization flow, BB2 search BFD using hicn hash or mbi hash
2. After authorization succeeded, BB2 retrieve FHIR resource e.g. EOB, Coverage, Patient.

By design, this setting will affect all BB2 to BFD communications, so if in the future, 
there are more BB2 to BFD call added, changes need to be made accordingly. 

### What Does This PR Do?

This PR enabled (exposed) VERIFY_SERVER setting in BB2 base settings, and put default as True
This PR introduced CA_BUNDLE setting in BB2 base settings, serve as path pointing to trusted server certificate (in pem format)
the default location is under the same certstore where BB2 client cert and private key are located, the default trusted server cert file name : ca_bundle.pem

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->


### What Should Reviewers Watch For?

Reviewer verify the server verify is working by observing:

1. When VERIFY_SERVER is True (default), and CA_BUNDLE is provided with a valid trusted server certificate of the target BFD server, the server verify will be performed when BB2 sends request to BFD, 
this can also be verified by observing the log where a WARNING does not present:

`/usr/local/lib/python3.6/site-packages/urllib3/connectionpool.py:847: InsecureRequestWarning: Unveri
fied HTTPS request is being made. Adding certificate verification is strongly advised. See: https://
urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)`

2. When VERIFY_SERVER is True but CA_BUNDLE is missing or the certificate is bad, SSL handshake will fail, error message like : SSL certificate verify failed e.g. will be logged.

3. When VERIFY_SERVER is set to False, "InsecureRequestWarning" will present in the log.

4. Check README.md under docker-compose/certstore for instructions for obtaining and install trusted server certificate.

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check these things, in particular:

* TODO


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
    * Does this PR add any new software dependencies? **Yes** or **No**.
    * Does this PR modify or invalidate any of our security controls? **Yes** or **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **Yes** or **No**.
* If the answer to any of the questions below is **Yes**, then please add @StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **Yes** or **No**.


### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following pre-requisite changes have been fully deployed:

* CMSgov/some_repo#42


### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
* [ ] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [ ] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
