### PR TITLE
[ BB2-2130 ] Fix for oauth2_provider.models:DoesNotExist exception edge case

### DIFF
--- a/apps/authorization/permissions.py
+++ b/apps/authorization/permissions.py
@@ -9,10 +9,15 @@ class DataAccessGrantPermission(permissions.BasePermission):
     Permission check for a Grant related to the token used.
     """
     def has_permission(self, request, view):
-        dag = DataAccessGrant.objects.get(
-            beneficiary=request.auth.user,
-            application=request.auth.application
-        )
+        dag = None
+        try:
+            dag = DataAccessGrant.objects.get(
+                beneficiary=request.auth.user,
+                application=request.auth.application
+            )
+        except DataAccessGrant.DoesNotExist:
+            return False
+
         if dag:
             if dag.has_expired():
                 raise exceptions.NotAuthenticated(


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-2130](https://jira.cms.gov/browse/BB2-2130)

**User Story or Bug Summary:**

This is a fix for an edge case producing the following exception:  oauth2_provider.models:DoesNotExist: Grant matching query does not exist

For example, this is occasionally showing up in New Relic.

ROOT CAUSE:

This occurs when a DataAccessGrant record does not exist and an AccessToken exists.

### What Does This PR Do?

- FILE: `apps/authorization/tests/test_data_access_grant_permissions.py`
  - TEST METHOD: `test_data_access_grant_permissions_has_permission()`
    - A failing test was created to reproduce the exception.
    - See comments in the test code for more details.
    - After the code change, the test was updated to pass.

- FILE: `apps/authorization/permissions.py`
  - METHOD: `DataAccessGrantPermission.has_permission()`
    - Add TRY block and catch DoesNotExist exception.

### What Should Reviewers Watch For?


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

- If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
  - Does this PR add any new software dependencies? **No**.
  - Does this PR modify or invalidate any of our security controls? **No**.
  - Does this PR store or transmit data that was not stored or transmitted before? **No**.
- If the answer to any of the questions below is **Yes**, then please add StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
  - Do you think this PR requires additional review of its security implications for other reasons? **No**.

### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* New features in external dependencies (e.g. BB2-API).
-->


<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

- [x] This PR is reasonably limited in scope, to help ensure that:
  1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
  5. There isn't too much of a burden on reviewers.
  6. Any problems it causes have a small "blast radius".
  7. It'll be easier to rollback if that becomes necessary.
- [x] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
- [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
- [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
- [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
- [x] Reviews are requested from both:
  - At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
  - Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
- [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
  - Please review the standards every few months to ensure you're familiar with them.
