### PR TITLE
[BB2-1929] Fix us gov banner rendering issue on mobile device

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -40,7 +40,7 @@
     }  
 </script>
 <section class="ds-c-usa-banner" aria-label="Official government website">
-<header class="ds-c-usa-banner__header ds-c-usa-banner__header--mobile" style="background-color:#f2f2f2; padding: 8px 16px 8px 16px;">
+<header class="ds-c-usa-banner__header" style="background-color:#f2f2f2; padding: 8px 16px 8px 16px;">
     <svg
         aria-hidden="false"
         class="ds-c-icon ds-c-icon--usa-flag ds-c-usa-banner__header-flag"
@@ -66,12 +66,10 @@
         ></path>
         </g>
     </svg>
-    <span class="ds-c-usa-banner__header-text">
-        <span style="white-space: nowrap">An official website of the United States government</span>
-    </span>
-    <button onclick="toggleBanner()" class="ds-c-usa-banner__button" style="background-color:#f2f2f2; padding: 0; width: fit-content;" aria-expanded="false" aria-controls="gov-banner_25">
-        <span class="ds-c-usa-banner__button-text" style="background-color:#f2f2f2;">Here’s how you know</span>
-        <span>
+    <p class="ds-c-usa-banner__header-text">
+        <span>An official website of the United States government</span>
+        <button onclick="toggleBanner()" class="ds-c-usa-banner__button" style="background-color:#f2f2f2; padding: 0; width: fit-content;" aria-expanded="false" aria-controls="gov-banner_25">
+            <span class="ds-c-usa-banner__button-text" style="background-color:#f2f2f2;">Here’s how you know</span>
             <svg
             aria-hidden="true"
             class="ds-c-icon ds-c-icon--arrow ds-c-icon--arrow-down ds-c-usa-banner__action-icon"
@@ -86,8 +84,8 @@
                 d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
             ></path>
             </svg>
-        </span>
-    </button>
+        </button>
+    </p>
 </header>
 <div class="ds-c-usa-banner__content" id="gov-banner_25" hidden="">
     <div class="ds-c-usa-banner__guidance-container">


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-1929](https://jira.cms.gov/browse/BB2-1929)

**User Story or Bug Summary:**
<!-- Please copy-paste the brief user story or bug description that this PR is intended to address. -->
DESCRIPTION

On my Android, there is a text wrapping issue with the "Here's how you know" text. The text should tuck under "An official website of the US Government" like it does on Medicare.gov.

(see attached screenshots)

![Screenshot_20221219_105812_Chrome](https://user-images.githubusercontent.com/25412191/229637497-87322efd-0146-4d75-b6f6-dc8f3552a077.jpg)

![Screenshot_20221219_110446_Chrome](https://user-images.githubusercontent.com/25412191/229637549-305f38a6-f622-41a6-8700-9cf671294a6e.jpg)

ACCEPTANCE CRITERIA

"Here's how you know" text appears under "An official website of the US Government"

This bug affects Android users accessing the static site or the permissions screen as part of an app authorization flow. 

QA

1. Button link label text "Here's how you know" appears under "An official website of the US Government" on Android phones (or any mobile device with narrow screen size)
2. Button link "Here's how you know" text appears" will appear on the right hand side of text "An official website of the US Government" on a desktop browser

To test the visual effect and rendering behavior of the US gov banner widgets on BB2 API web pages and BB2 site static:

Chrome browser's developer mode has a "Toggle device toolbar" can be used to simulate a mobile device rendering effects:

See screen shots in jira for details.


### What Does This PR Do?

Changed the web elements and css classes such that the US gov banner widgets render just like other CMS/HHS gov site's US gov banner widgets - for example when rendered on mobile device, the button with text label "Here's how you know" will appear under text "An official  website of the US Government"

<!--
Add detailed description & discussion of changes here.
The contents of this section should be used as your commit message (unless you merge the PR via a merge commit, of course).

Please follow standard Git commit message guidelines:
* First line should be a capitalized, short (50 chars or less) summary.
* The rest of the message should be in standard Markdown format, wrapped to 72 characters.
* Describe your changes in imperative mood, e.g. "make xyzzy do frotz" instead of "[This patch] makes xyzzy do frotz" or "[I] changed xyzzy to do frotz", as if you are giving orders to the codebase to change its behavior.
* List all relevant Jira issue keys, one per line at the end of the message, per: <https://confluence.atlassian.com/jirasoftwarecloud/processing-issues-with-smart-commits-788960027.html>.

Reference: <https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project>.
-->


### What Should Reviewers Watch For?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply for some reason.

Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

Reviewer can check the rendering behavior of the US gov site banner widgets on Blue Button API web pages, and on Blue Button 2.0 static site pages as well.

QA testers can either use a real phone or browser's mobile device simulation mode (as with Chrome), note that using a mobile phone to test probably requires that the fix is deployed to PROD / SBX, or set your phone on CMS VPN ?

When testing please test:

1. US gov site widgets render as expected on mobile device
2. US gov site widgets render as expected on wide screen e.g. desk top browsers
3. Resize the screen in both mobile phone (or simulator) and browsers and compare with one of the other CMS/HHS sites - e.g. medicare.gov, or DPC etc. and verify that the rendering behavior is the same

If you're reviewing this PR, please check these things, in particular:

* TODO


### What Security Implications Does This PR Have?

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
    * Does this PR add any new software dependencies? **No**.
    * Does this PR modify or invalidate any of our security controls? **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **No**.
* If the answer to any of the questions below is **Yes**, then please add StewGoin as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **No**.


### What Needs to Be Merged and Deployed Before this PR?

<!--
Add some items to the following list, or remove the entire section if it doesn't apply.

Common items include:
* Database migrations (which should always be deployed by themselves, to reduce risk).
* New features in external dependencies (e.g. BFD).
-->

This PR cannot be either merged or deployed until the following pre-requisite changes have been fully deployed:

* CMSgov/some_repo#42
  
### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
  * [ ] The migrations should be run PRIOR to the code being deployed
  * [ ] The migrations should be run AFTER the code is deployed
  * [ ] There is a more complicated migration plan (downtime, etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations


### Submitter Checklist

<!--
Helpful hint: if needed, Git allows you to edit your PR's commits and history, prior to merge.
See these resources for more information:

* <https://dev.to/maxwell_dev/the-git-rebase-introduction-i-wish-id-had>
* <https://raphaelfabeni.com/git-editing-commits-part-1/>
-->

I have gone through and verified that...:

* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    5. There isn't too much of a burden on reviewers.
    6. Any problems it causes have a small "blast radius".
    7. It'll be easier to rollback if that becomes necessary.
* [x] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
