### PR TITLE
BB2-3232: Filter inactive accounts

### DIFF
--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -32,7 +32,7 @@ class UserTypeFilter(admin.SimpleListFilter):
 
 class ActiveAccountFilter(admin.SimpleListFilter):
     title = "User activation status"
-    parameter_name = "is_active"
+    parameter_name = "status"
 
     def lookups(self, request, model_admin):
         return [

--- a/apps/accounts/admin.py
+++ b/apps/accounts/admin.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from django.contrib import admin
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin as DjangoUserAdmin
@@ -8,7 +9,6 @@ from .models import (
     ActivationKey,
     UserIdentificationLabel,
 )
-
 
 admin.site.register(ActivationKey)
 admin.site.register(ValidPasswordResetKey)
@@ -30,8 +30,36 @@ class UserTypeFilter(admin.SimpleListFilter):
         return queryset
 
 
-class UserAdmin(DjangoUserAdmin):
+class ActiveAccountFilter(admin.SimpleListFilter):
+    title = "User activation status"
+    parameter_name = "is_active"
 
+    def lookups(self, request, model_admin):
+        return [
+            ("active", "Active"),
+            ("inactive_all", "Inactive"),
+            ("inactive_expired", "Inactive (expired activation key)")
+        ]
+
+    def queryset(self, request, queryset):
+        if self.value() == "inactive_expired":
+            return queryset.filter(
+                is_active=False,
+                activationkey__key_status="expired",
+            ) | queryset.filter(
+                # Since the activation keys only reach "expired" status when they are
+                # used post-expiration, we need to check the "created" status as well
+                is_active=False,
+                activationkey__key_status="created",
+                activationkey__expires__lt=(datetime.today()),
+            )
+        elif self.value() == "inactive_all":
+            return queryset.filter(is_active=False)
+        elif self.value() == "active":
+            return queryset.filter(is_active=True)
+
+
+class UserAdmin(DjangoUserAdmin):
     list_display = (
         "username",
         "get_type",
@@ -43,7 +71,7 @@ class UserAdmin(DjangoUserAdmin):
         "date_joined",
     )
 
-    list_filter = (UserTypeFilter,)
+    list_filter = (UserTypeFilter, ActiveAccountFilter,)
 
     @admin.display(
         description="Type",


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-3232](https://jira.cms.gov/browse/BB2-3232)

**User Story or Bug Summary:**
I'd like to delete sandbox accounts which have had their activation keys expired. To facilitate this, I'm delivering code that will add some filters to the Users view in Django admin. We will now be able to filter by `Active` (users with Active status), `Inactive` (users with Inactive status), and `Inactive (expired activation key)` (users with inactive status and an expired activation key). By selecting the third option, it will be simple to delete all never-activated users as required by the ticket.

### What Does This PR Do?
This PR adds a new filter to the Users admin view as described above.


### What Should Reviewers Watch For?
If you have any knowledge of places we have unit tested this kind of code, let me know! I would love to add unit tests for this, but was unsure of where that would go or how it would work. Open to pairing as well.

You should test this by creating new accounts locally, to have a variety of cases in your User pool:

1. An active account
2. An account that once was active, but is no longer (should be fine to do this with Fred by deactivating him temporarily)
3. An account that is inactive and whose key is expired (in reality this would be done by clicking on the activation link after the `expires` date`, but you can just update the status of the activation key to `expired`)
4. An account that is inactive, whose key status is `created`, and whose key `expires` is in the past
5. An account that is inactive, whose key status is `created`, and whose key `expires` is in the future

It wasn't straightforward to adjust the expires value of the activation key to be in the past, so you can adjust the logic in the filter temporarily to test that case by changing `datetime.today()` to something like `datetime.today()+timedelta(days=7)`.

We would expect that `Active` would give you account 1, `Inactive` would give you 2, 3, 4, 5, and `Inactive (expired activation key)` would give you 3, 4.

### What Security Implications Does This PR Have?
None


### What Needs to Be Merged and Deployed Before this PR?
None
  
### Any Migrations?
* [x] No migrations


### Submitter Checklist
I have gone through and verified that...:

* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
