### PR TITLE
BB2-2660: Move logic from save to clean for oauth client and grant type

### DIFF
--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -88,6 +88,8 @@ class CustomRegisterApplicationForm(forms.ModelForm):
     required_css_class = "required"
 
     def clean(self):
+        self.cleaned_data['client_type'] = "confidential"
+        self.cleaned_data['authorization_grant_type'] = "authorization-code"
         return self.cleaned_data
 
     def clean_name(self):
@@ -155,8 +157,6 @@ class CustomRegisterApplicationForm(forms.ModelForm):
         return require_demographic_scopes
 
     def save(self, *args, **kwargs):
-        self.instance.client_type = "confidential"
-        self.instance.authorization_grant_type = "authorization-code"
         app = self.instance
         # Only log agreement from a Register form
         if app.agree and type(self) == CustomRegisterApplicationForm:

--- a/apps/dot_ext/tests/test_form_application.py
+++ b/apps/dot_ext/tests/test_form_application.py
@@ -258,6 +258,31 @@ class TestRegisterApplicationForm(BaseApiTest):
         form = CustomRegisterApplicationForm(user, passing_app_fields)
         self.assertTrue(form.is_valid())
 
+        # Test client_type = 'confidential' and authorization_grant_type = 'authorization-code' regardless of input
+        data = passing_app_fields
+        data['client_type'] = 'confidential'
+        data['authorization_grant_type'] = 'implicit'
+        form = CustomRegisterApplicationForm(user, data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data.get('client_type'), 'confidential')
+        self.assertEqual(form.cleaned_data.get('authorization_grant_type'), 'authorization-code')
+
+        data = passing_app_fields
+        data['client_type'] = 'public'
+        data['authorization_grant_type'] = 'authorization-code'
+        form = CustomRegisterApplicationForm(user, data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data.get('client_type'), 'confidential')
+        self.assertEqual(form.cleaned_data.get('authorization_grant_type'), 'authorization-code')
+
+        data = passing_app_fields
+        data['client_type'] = 'public'
+        data['authorization_grant_type'] = 'implicit'
+        form = CustomRegisterApplicationForm(user, data)
+        self.assertTrue(form.is_valid())
+        self.assertEqual(form.cleaned_data.get('client_type'), 'confidential')
+        self.assertEqual(form.cleaned_data.get('authorization_grant_type'), 'authorization-code')
+
     def test_create_applications_with_logo(self):
         """
         regression test: BB2-66: Fix-logo-display-in-Published-Applications-API


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-2660](https://jira.cms.gov/browse/BB2-2660)

**User Story or Bug Summary:**
This is a continuation of work done in https://github.com/CMSgov/bluebutton-web-server/pull/1203. There was some discussion during that PR about where some logic should go, but we ended up not making a change because we couldn't get that working. We've since delivered that PR, but this PR covers those adjustments.

### What Does This PR Do?
This PR moves all of the logic for the hardcoding of the oauth settings into the clean function instead of the save function. It also reintroduces some unit tests, but where before they would verify that the form is invalid, they now verify that regardless of input, the resulting cleaned data is the same. It may be useful to compare the new form of those tests with what was there before #1203.


### What Should Reviewers Watch For?
All of the same things that were relevant in #1203 are still relevant. We should make sure there is no regression by testing adding/editing apps locally.

### What Security Implications Does This PR Have?
 None.

Submitters should complete the following questionnaire:

* If the answer to any of the questions below is **Yes**, then here's a link to the associated Security Impact Assessment (SIA), security checklist, or other similar document in Confluence: N/A.
    * Does this PR add any new software dependencies? **Yes** or **No**.
    * Does this PR modify or invalidate any of our security controls? **Yes** or **No**.
    * Does this PR store or transmit data that was not stored or transmitted before? **Yes** or **No**.
* If the answer to any of the questions below is **Yes**, then please add a Security Engineer and ISSO  as a reviewer, and note that this PR should not be merged unless/until he also approves it.
    * Do you think this PR requires additional review of its security implications for other reasons? **Yes** or **No**.


### What Needs to Be Merged and Deployed Before this PR?
None
  
### Any Migrations?
None

### Submitter Checklist
I have gone through and verified that...:

* [x] This PR is reasonably limited in scope, to help ensure that:
    1. It doesn't unnecessarily tie a bunch of disparate features, fixes, refactorings, etc. together.
    2. There isn't too much of a burden on reviewers.
    3. Any problems it causes have a small "blast radius".
    4. It'll be easier to rollback if that becomes necessary.
* [x] I have named this PR and its branch such that they'll be automatically be linked to the (most) relevant Jira issue, per: <https://confluence.atlassian.com/adminjiracloud/integrating-with-development-tools-776636216.html>.
* [x] This PR includes any required documentation changes, including `README` updates and changelog / release notes entries.
* [x] All new and modified code is appropriately commented, such that the what and why of its design would be reasonably clear to engineers, preferably ones unfamiliar with the project.
* [x] All tech debt and/or shortcomings introduced by this PR are detailed in `TODO` and/or `FIXME` comments, which include a JIRA ticket ID for any items that require urgent attention.
* [x] Reviews are requested from both:
    * At least two other engineers on this project, at least one of whom is a senior engineer or owns the relevant component(s) here.
    * Any relevant engineers on other projects (e.g. BFD, SLS, etc.).
* [x] Any deviations from the other policies in the [DASG Engineering Standards](https://github.com/CMSgov/cms-oeda-dasg/blob/master/policies/engineering_standards.md) are specifically called out in this PR, above.
    * Please review the standards every few months to ensure you're familiar with them.
