### PR TITLE
BB-3317: Deprecate using hashed MBI to lookup FHIR_ID in BB2 authorization flow, use MBI instead

### DIFF
--- a/apps/fhir/server/authentication.py
+++ b/apps/fhir/server/authentication.py
@@ -1,4 +1,3 @@
-import json
 import requests
 
 from django.conf import settings
@@ -82,7 +81,7 @@ def search_fhir_id_by_identifier(search_identifier, request=None):
     url = f"{get_resourcerouter().fhir_url}/{ver}/fhir/Patient/_search"
     s = requests.Session()
 
-    payload = json.dumps({"identifier": search_identifier})
+    payload = {"identifier": search_identifier}
     req = requests.Request('POST', url, headers=headers, data=payload)
     prepped = req.prepare()
     pre_fetch.send_robust(FhirServerAuth, request=req, auth_request=request, api_ver=ver)
@@ -141,10 +140,10 @@ def match_fhir_id(mbi, mbi_hash, hicn_hash, request=None):
         fhir_id = Matched patient identifier.
         hash_lookup_type = The type used for the successful lookup (M or H).
       Raises exceptions:
-        UpstreamServerException: If hicn_hash or mbi_hash search found duplicates.
+        UpstreamServerException: If hicn_hash or mbi search found duplicates.
         NotFound: If both searches did not match a fhir_id.
     """
-    # Perform primary lookup using MBI_HASH
+    # Perform primary lookup using MBI
     if mbi:
         try:
             fhir_id = search_fhir_id_by_identifier_mbi(mbi, request)

--- a/apps/fhir/server/authentication.py
+++ b/apps/fhir/server/authentication.py
@@ -1,3 +1,4 @@
+import json
 import requests
 
 from django.conf import settings
@@ -81,7 +82,7 @@ def search_fhir_id_by_identifier(search_identifier, request=None):
     url = f"{get_resourcerouter().fhir_url}/{ver}/fhir/Patient/_search"
     s = requests.Session()
 
-    payload = {"identifier": search_identifier}
+    payload = json.dumps({"identifier": search_identifier})
     req = requests.Request('POST', url, headers=headers, data=payload)
     prepped = req.prepare()
     pre_fetch.send_robust(FhirServerAuth, request=req, auth_request=request, api_ver=ver)
@@ -144,7 +145,7 @@ def match_fhir_id(mbi, mbi_hash, hicn_hash, request=None):
         NotFound: If both searches did not match a fhir_id.
     """
     # Perform primary lookup using MBI_HASH
-    if mbi_hash:
+    if mbi:
         try:
             fhir_id = search_fhir_id_by_identifier_mbi(mbi, request)
         except UpstreamServerException as err:

--- a/apps/fhir/server/tests/test_authentication.py
+++ b/apps/fhir/server/tests/test_authentication.py
@@ -14,7 +14,8 @@ class TestAuthentication(BaseApiTest):
     MOCK_FHIR_URL = "fhir.backend.bluebutton.hhsdevcloud.us"
     MOCK_FHIR_PATH = "/v1/fhir/Patient/"
     MOCK_FHIR_HICN_QUERY = ".*hicnHash.*"
-    MOCK_FHIR_MBI_QUERY = ".*mbi-hash.*"
+    # MOCK_FHIR_MBI_QUERY = ".*mbi-hash.*"
+    MOCK_FHIR_MBI_QUERY = ".*us-mbi|.*"
 
     def setUp(self):
         # Setup the RequestFactory
@@ -79,6 +80,7 @@ class TestAuthentication(BaseApiTest):
         '''
         with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_success_mock):
             fhir_id, hash_lookup_type = match_fhir_id(
+                mbi=self.test_mbi_hash,
                 mbi_hash=self.test_mbi_hash,
                 hicn_hash=self.test_hicn_hash, request=self.request)
             self.assertEqual(fhir_id, "-20000000002346")
@@ -92,6 +94,7 @@ class TestAuthentication(BaseApiTest):
         '''
         with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_not_found_mock):
             fhir_id, hash_lookup_type = match_fhir_id(
+                mbi=self.test_mbi_hash,
                 mbi_hash=self.test_mbi_hash,
                 hicn_hash=self.test_hicn_hash, request=self.request)
             self.assertEqual(fhir_id, "-20000000002346")
@@ -105,6 +108,7 @@ class TestAuthentication(BaseApiTest):
         '''
         with HTTMock(self.fhir_match_hicn_not_found_mock, self.fhir_match_mbi_success_mock):
             fhir_id, hash_lookup_type = match_fhir_id(
+                mbi=self.test_mbi_hash,
                 mbi_hash=self.test_mbi_hash,
                 hicn_hash=self.test_hicn_hash, request=self.request)
             self.assertEqual(fhir_id, "-20000000002346")
@@ -119,6 +123,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_not_found_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaises(exceptions.NotFound):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -131,6 +136,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_error_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaises(HTTPError):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -143,6 +149,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_not_found_mock, self.fhir_match_mbi_error_mock):
             with self.assertRaises(HTTPError):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -155,6 +162,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_duplicates_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -167,6 +175,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_duplicates_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -179,6 +188,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_duplicates_mock, self.fhir_match_mbi_duplicates_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -191,6 +201,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_malformed_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Unexpected result found*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -203,6 +214,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_malformed_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Unexpected result found*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -217,6 +229,7 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_lying_mock, self.fhir_match_mbi_not_found_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)
 
@@ -231,5 +244,6 @@ class TestAuthentication(BaseApiTest):
         with HTTMock(self.fhir_match_hicn_success_mock, self.fhir_match_mbi_lying_mock):
             with self.assertRaisesRegexp(UpstreamServerException, "^Duplicate.*"):
                 fhir_id, hash_lookup_type = match_fhir_id(
+                    mbi=self.test_mbi_hash,
                     mbi_hash=self.test_mbi_hash,
                     hicn_hash=self.test_hicn_hash, request=self.request)

--- a/apps/fhir/server/tests/test_authentication.py
+++ b/apps/fhir/server/tests/test_authentication.py
@@ -36,8 +36,9 @@ class TestAuthentication(BaseApiTest):
         @urlmatch(netloc=cls.MOCK_FHIR_URL, path=cls.MOCK_FHIR_PATH, method='POST')
         def mock_fhir_post(url, request):
             try:
-                body = json.loads(request.body)
-                identifier = body.get('identifier', '')
+                body = request.body
+                identifier = body.split('=', 1)[1]
+
                 if 'hicn-hash' in identifier:
                     return responses[hicn_response_key]
                 elif 'us-mbi' in identifier:

--- a/apps/mymedicare_cb/models.py
+++ b/apps/mymedicare_cb/models.py
@@ -55,7 +55,6 @@ def get_and_update_user(slsx_client: OAuth2ConfigSLSx, request=None):
     fhir_id, hash_lookup_type = match_fhir_id(
         mbi=slsx_client.mbi,
         mbi_hash=slsx_client.mbi_hash,
-        hicn=slsx_client.hicn,
         hicn_hash=slsx_client.hicn_hash, request=request
     )
 

--- a/apps/mymedicare_cb/models.py
+++ b/apps/mymedicare_cb/models.py
@@ -53,7 +53,9 @@ def get_and_update_user(slsx_client: OAuth2ConfigSLSx, request=None):
 
     # Match a patient identifier via the backend FHIR server
     fhir_id, hash_lookup_type = match_fhir_id(
+        mbi=slsx_client.mbi,
         mbi_hash=slsx_client.mbi_hash,
+        hicn=slsx_client.hicn,
         hicn_hash=slsx_client.hicn_hash, request=request
     )
 

--- a/apps/test.py
+++ b/apps/test.py
@@ -35,6 +35,7 @@ class BaseApiTest(TestCase):
 
     test_hicn_hash = "96228a57f37efea543f4f370f96f1dbf01c3e3129041dba3ea4367545507c6e7"
     test_mbi_hash = "98765432137efea543f4f370f96f1dbf01c3e3129041dba3ea43675987654321"
+    test_mbi = "1SA0A00AA00"
 
     def _create_user(
         self,

--- a/hhs_oauth_server/settings/base.py
+++ b/hhs_oauth_server/settings/base.py
@@ -593,16 +593,26 @@ FHIR_SERVER = {
     "CLIENT_AUTH": True,
 }
 
-"""
-    FHIR URL search query parameters for backend /Patient resource
-    See FHIR and/or BFD specs for "identifier" and "_format" params.
-"""
-FHIR_SEARCH_PARAM_IDENTIFIER_MBI_HASH = (
-    "https%3A%2F%2Fbluebutton.cms.gov" + "%2Fresources%2Fidentifier%2Fmbi-hash"
+FHIR_POST_SEARCH_PARAM_IDENTIFIER_MBI_HASH = (
+    "https://bluebutton.cms.gov/resources/identifier/mbi-hash"
 )
-FHIR_SEARCH_PARAM_IDENTIFIER_HICN_HASH = (
-    "http%3A%2F%2Fbluebutton.cms.hhs.gov%2Fidentifier%23hicnHash"
+
+FHIR_POST_SEARCH_PARAM_IDENTIFIER_HICN_HASH = (
+    "https://bluebutton.cms.gov/resources/identifier/hicn-hash"
 )
+
+"""
+    (mbi, hicn, etc); the following are all valid values for Identifier, and all might represent the same resource:
+        - `identifier=https://bluebutton.cms.gov/resources/identifier/hicn-hash|<your hicn hash>`
+        - `identifier=https://bluebutton.cms.gov/resources/identifier/mbi-hash|<your mbi hash>`
+        - `identifier=http://hl7.org/fhir/sid/us-mbi|<your mbi>`
+    example: "http://hl7.org/fhir/sid/us-mbi|<your mbi>"
+"""
+
+FHIR_PATIENT_SEARCH_PARAM_IDENTIFIER_MBI = (
+    "http://hl7.org/fhir/sid/us-mbi"
+)
+
 FHIR_PARAM_FORMAT = "json"
 
 # Timeout for request call


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3317](https://jira.cms.gov/browse/BB2-3317)

### What Does This PR Do?
Deprecate using hashed MBI to lookup FHIR_ID in BB2 authorization flow, use MBI instead
<!--
Add detailed description & discussion of changes here.
-->

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
