### PR TITLE
BB2-3357: Updates to autoincrement script

### DIFF
--- a/ops/build_autoincrement_release.sh
+++ b/ops/build_autoincrement_release.sh
@@ -9,7 +9,7 @@ declare -A hash2namesref=( ["k1"]="v1")
 get_hash2pr_map() {
     commit_hash_refnames_regex="^([a-f0-9]{40})[[:blank:]]*(.*)"
     refnames_pr_id_regex="^\(.*/pr/([0-9]+).*\)"
-    GIT_LOG_LHASH2REFNAMES="$(mktemp /tmp/$(basename $0).XXXXXX.h2refnames)"
+    GIT_LOG_LHASH2REFNAMES="$(mktemp /tmp/$(basename $0).h2refnames.XXXXXX)"
     git log --pretty=format:'%H %d' ${COMMIT_RANGE} > ${GIT_LOG_LHASH2REFNAMES}
     while read -r line || [ -n "$line" ]; do
         line=$(echo "$line" | xargs)
@@ -35,7 +35,7 @@ get_hash2pr_map() {
 # return release history string with '\n' delimited
 generate_release_history() {
     commit_hash_subj_regex="^([a-f0-9]{40})[[:blank:]]+(.+)(\(\#[0-9]+\))?"
-    GIT_LOG_LHASH2SUBJ="$(mktemp /tmp/$(basename $0).XXXXXX.h2subj)"
+    GIT_LOG_LHASH2SUBJ="$(mktemp /tmp/$(basename $0).h2subj.XXXXXX)"
     git log --pretty=format:'%H %s' ${COMMIT_RANGE} > ${GIT_LOG_LHASH2SUBJ}
     rel_hist=""
     while read -r line || [ -n "$line" ]; do
@@ -65,7 +65,7 @@ generate_release_history() {
 # $2 - ${NEW_RELEASE_DATE}
 # $3 - ${NEW_RELEASE_HISTORY}
 write_release_note() {
-    GITHUB_RELEASE_PAYLOAD="$(mktemp /tmp/$(basename $0).XXXXXX)"
+    GITHUB_RELEASE_PAYLOAD="$(mktemp /tmp/$(basename $0).releasePayload.XXXXXX)"
     echo "{" > "${GITHUB_RELEASE_PAYLOAD}"
     echo '"tag_name":' "\"$1\"," >> "${GITHUB_RELEASE_PAYLOAD}"
     echo '"name":' "\"$1\"," >> "${GITHUB_RELEASE_PAYLOAD}"
@@ -109,7 +109,7 @@ fi
 
 # Detect if running from a fork
 #
-GITHUB_REPO="$(git ls-remote --quiet --get-url | grep -o '[^:/]\{1,\}/bluebutton-web-server')"
+GITHUB_REPO="$(git ls-remote --get-url | grep -o '[^:/]\{1,\}/bluebutton-web-server')"
 
 # Test running from root of repository
 #
@@ -169,14 +169,16 @@ get_hash2pr_map
 NEW_RELEASE_HISTORY=$(generate_release_history)
 
 if [[ -z "${NEW_RELEASE_HISTORY}" ]]; then
-   echo "No commits detected since previous release, no need for a new release, exiting."
-   exit 0
+    echo "No commits detected since previous release, no need for a new release, exiting."
+    rm "/tmp/$(basename $0)"*
+    exit 0
 fi
 
 # Create and push new release tag
 #
+echo "Pushing new tag"
 git tag -a -s -m "Blue Button API release $NEW_RELEASE_TAG" "$NEW_RELEASE_TAG"
-git push --quiet --tags
+git push --tags
 
 # Create GitHub release template
 #
@@ -184,7 +186,7 @@ write_release_note "${NEW_RELEASE_TAG}" "${NEW_RELEASE_DATE}" "${NEW_RELEASE_HIS
 
 # Create GitHub release via API request
 #
-GITHUB_RELEASE_STATUS="$(mktemp /tmp/$(basename $0).XXXXXX)"
+GITHUB_RELEASE_STATUS="$(mktemp /tmp/$(basename $0).releaseStatus.XXXXXX)"
 
 curl -s -X POST -H "Accept: application/vnd.github.v3+json" \
                 -H "Authorization: token ${GITHUB_ACCESS_TOKEN}" \
@@ -192,16 +194,21 @@ curl -s -X POST -H "Accept: application/vnd.github.v3+json" \
                 --data-binary "@${GITHUB_RELEASE_PAYLOAD}" > "${GITHUB_RELEASE_STATUS}"
 
 # Verify GitHub release
-if [[ "$(grep '"errors":' ${GITHUB_RELEASE_STATUS})" ]]; then
+if grep -q "\"tag_name\": \"${NEW_RELEASE_TAG}\"" "${GITHUB_RELEASE_STATUS}"
+then
+    echo "Release created successfully: https://github.com/${GITHUB_REPO}/releases/tag/${NEW_RELEASE_TAG}"
+    rm "/tmp/$(basename $0)"*
+    exit 0
+else
     echo "Error during release creation, dumping debug output!"
     echo "Release JSON payload:"
     cat "${GITHUB_RELEASE_PAYLOAD}"
     echo "Release API status:"
     cat "${GITHUB_RELEASE_STATUS}"
+    echo "Rolling back pushed tag"
+    git push -d origin "$NEW_RELEASE_TAG"
+    echo "Deleting local tag"
+    git tag -d "$NEW_RELEASE_TAG"
     rm "/tmp/$(basename $0)"*
     exit 1
-else
-    echo "Release created successfully: https://github.com/${GITHUB_REPO}/releases/tag/${NEW_RELEASE_TAG}"
-    rm "/tmp/$(basename $0)"*
-    exit 0
 fi


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3357](https://jira.cms.gov/browse/BB2-3357)

### What Does This PR Do?

- fixes some of the error catching in the auto increment release script
- eliminates tmp file name collisions and adds tmp cleanup to more cases
- adds more verbose output to make it easier to see what the script is doing, and to see where it may be failing
- deletes any created tags if the tags are created but the release creation fails.

(Note that this is the exact same PR as #1242, but since that was opened from a fork, some of our Jenkins checks wouldn't work, so had to open this instead. Good to know for next time!)

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

- Is the level of detail in the snippets below adequate?
- Any unaddressed concerns or pain points?

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

Ran this without issue in the forked repo:

```
➜  bluebutton-web-server git:(master) ✗ ./ops/build_autoincrement_release.sh
Build auto increment release...
Pushing new tag
Enumerating objects: 1, done.
Counting objects: 100% (1/1), done.
Writing objects: 100% (1/1), 806 bytes | 806.00 KiB/s, done.
Total 1 (delta 0), reused 0 (delta 0), pack-reused 0
To https://github.com/jimmyfagan/bluebutton-web-server.git
 * [new tag]           r2 -> r2
Release created successfully: https://github.com/jimmyfagan/bluebutton-web-server/releases/tag/r2
```

Additionally did some testing by using this script in the main repo with my SSO deauthorized and got this:

```
➜  bluebutton-web-server git:(master) ✗ ./ops/build_autoincrement_release.sh                               
Build auto increment release...
Error during release creation, dumping debug output!
Release JSON payload:
{
"tag_name": "r129",
"name": "r129",
"body": "r129 - 2024-09-06\n================\n\n- BB2-3327: Fix date comparisons in selenium tests (#1240) ",
"draft": false,
"prerelease": false
}
Release API status:
{
  "message": "Resource protected by organization SAML enforcement. You must grant your Personal Access token access to this organization.",
  "documentation_url": "https://docs.github.com/articles/authenticating-to-a-github-organization-with-saml-single-sign-on/",
  "status": "403"
}
Rolling back pushed tag
To https://github.com/CMSgov/bluebutton-web-server
 - [deleted]           r129
Deleting local tag
Deleted tag 'r129' (was ed11736f)
```

Previously that case would have reported "Release created successfully"

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
