### PR TITLE
BB2-3520: Undo short-term fix and adjust tests

### DIFF
--- a/apps/capabilities/permissions.py
+++ b/apps/capabilities/permissions.py
@@ -37,20 +37,15 @@ class TokenHasProtectedCapability(permissions.BasePermission):
                 slug__in=token_scopes
             ).values_list('protected_resources', flat=True).all())
 
-            # this is a shorterm fix to reject all tokens that do not have either
-            # patient/coverage.read or patient/ExplanationOfBenefit.read
-            if ("patient/Coverage.read" in token_scopes) or ("patient/ExplanationOfBenefit.read" in token_scopes):
-                for scope in scopes:
-                    for method, path in json.loads(scope):
-                        if method != request.method:
-                            continue
-                        if path == request.path:
-                            return True
-                        if re.fullmatch(path, request.path) is not None:
-                            return True
-                return False
-            else:
-                return False
+            for scope in scopes:
+                for method, path in json.loads(scope):
+                    if method != request.method:
+                        continue
+                    if path == request.path:
+                        return True
+                    if re.fullmatch(path, request.path) is not None:
+                        return True
+            return False
         else:
             # BB2-237: Replaces ASSERT with exception. We should never reach here.
             mesg = ("TokenHasScope requires the `oauth2_provider.rest_framework.OAuth2Authentication`"

--- a/apps/capabilities/tests.py
+++ b/apps/capabilities/tests.py
@@ -1,5 +1,4 @@
 import json
-import unittest
 
 from django.contrib.auth.models import Group
 from django.test import TestCase
@@ -41,7 +40,6 @@ class TestTokenHasProtectedCapabilityScopesSwitchTrue(TestCase):
             protected_resources=json.dumps([["POST", "/path"]]),
         )
 
-    @unittest.skip("Broke with quick fix")
     def test_request_is_protected(self):
         request = SimpleRequest("scope")
         request.method = "GET"

--- a/apps/dot_ext/forms.py
+++ b/apps/dot_ext/forms.py
@@ -335,7 +335,7 @@ class SimpleAllowForm(DotAllowForm):
             scope = ""
 
         # Remove demographic information scopes, if beneficiary is not sharing
-        if cleaned_data.get("share_demographic_scopes") == "False":
+        if cleaned_data.get("share_demographic_scopes") != "True":
             cleaned_data["scope"] = " ".join(
                 [
                     s

--- a/apps/dot_ext/tests/demographic_scopes_test_cases.py
+++ b/apps/dot_ext/tests/demographic_scopes_test_cases.py
@@ -181,7 +181,7 @@ VIEW_OAUTH2_SCOPES_TEST_CASES = {
         "request_scopes": APPLICATION_SCOPES_FULL,
         # Result:
         "result_has_error": False,
-        "result_token_scopes_granted": APPLICATION_SCOPES_FULL,
+        "result_token_scopes_granted": APPLICATION_SCOPES_NON_DEMOGRAPHIC,
         "result_access_token_count": 1,
         "result_refresh_token_count": 1,
         "result_archived_token_count": 0,
@@ -221,7 +221,7 @@ VIEW_OAUTH2_SCOPES_TEST_CASES = {
         "request_scopes": APPLICATION_SCOPES_FULL,
         # Result:
         "result_has_error": False,
-        "result_token_scopes_granted": APPLICATION_SCOPES_FULL,
+        "result_token_scopes_granted": APPLICATION_SCOPES_NON_DEMOGRAPHIC,
         "result_access_token_count": 3,
         "result_refresh_token_count": 3,
         "result_archived_token_count": 1,
@@ -314,7 +314,7 @@ VIEW_OAUTH2_SCOPES_TEST_CASES = {
         "request_scopes": SCOPES_JUST_PATIENT_AND_A,
         # Result:
         "result_has_error": False,
-        "result_token_scopes_granted": SCOPES_JUST_PATIENT_AND_A,
+        "result_token_scopes_granted": SCOPES_JUST_A,
         "result_access_token_count": 3,
         "result_refresh_token_count": 3,
         "result_archived_token_count": 8,

--- a/apps/dot_ext/tests/test_views.py
+++ b/apps/dot_ext/tests/test_views.py
@@ -1,6 +1,5 @@
 import json
 import base64
-import unittest
 from datetime import date, timedelta
 
 from django.conf import settings
@@ -163,20 +162,8 @@ class TestAuthorizationView(BaseApiTest):
         # and here we test that only the capability-a scope has been issued
         self.assertEqual(content["scope"], "capability-a")
 
-    @unittest.skip("Broke with quick fix")
-    def test_post_with_share_demographic_scopes(self):
-        # Test with-out new_auth switch
-        self.testing_post_with_share_demographic_scopes()
-
-    @unittest.skip("Broke with quick fix")
-    @override_switch("new_auth", active=True)
-    def test_post_with_share_demographic_scopes_new_auth_switch(self):
-        # Test with new_auth switch.
-        self.testing_post_with_share_demographic_scopes()
-
-    @unittest.skip("Broke with quick fix")
     @override_switch("require-scopes", active=True)
-    def testing_post_with_share_demographic_scopes(self):
+    def test_post_with_share_demographic_scopes(self):
         """
         Test authorization related to different, beneficiary "share_demographic_scopes",
         application.require_demographic_scopes, and requested scopes values.


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3520](https://jira.cms.gov/browse/BB2-3520)

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
-->

- Undoes short term fix in the permissions checks
- Unskips tests that were broken due to the short term fix
- Adjusts demographic scope removal to require `True` to keep demographic scopes (formerly would work for `None` as well, only relevant to unit tests)
- Removes duplicate tests which formerly utilized a waffle switch that is no longer in use

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:

- Any issues with changing the check for `== "False"` to a check for `!= "True"`
- Any issues with the validation plan below?

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

Tested this locally by trying to create a token with patient/profile scope, not selecting the demographic box and continuing. I failed to get a token as expected.
I then tested with selecting the demographic box, got a token back with patient/profile scope, and was able to use that for Patient and profile endpoints, but nothing else. All as expected. While this is out for review, and during the deployment cycle, I'll continue testing out a variety of other cases, most notably confirming that this works correctly for apps which don't display the demographic check box.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [x] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
