### PR TITLE
Add missing switches, alphabetize switches, support notes for switches.

### DIFF
--- a/apps/core/management/commands/create_test_feature_switches.py
+++ b/apps/core/management/commands/create_test_feature_switches.py
@@ -4,19 +4,20 @@ from waffle.models import Switch
 from apps.core.models import Flag
 
 WAFFLE_FEATURE_SWITCHES = (
-    ("enable_swaggerui", True, ""),
-    ("enable_testclient", True, ""),
-    ("expire_grant_endpoint", True, "This enables the /v<1/2>/o/expire_authenticated_user/<patient_id>/ endpoint"),
-    ("interim-prod-access", True, ""),
-    ("login", True, ""),
-    ("outreach_email", True, ""),
-    ("require-scopes", True, ""),
+    ("enable_swaggerui", True, "This enables a page for the openapi docs and a link to the page from the main page."),
+    ("enable_testclient", True, "This enables the test client."),
+    ("expire_grant_endpoint", True, "This enables the /v<1/2>/o/expire_authenticated_user/<patient_id>/ endpoint."),
+    ("interim-prod-access", True, "This controls access to the interim prod access form. \
+        This is outdated and will be removed in a future ticket"),
+    ("login", True, "This enables login related URLs and code. See apps/accounts/urls.py file for more info."),
+    ("outreach_email", True, "This enables developer outreach emails. Not active in prod."),
+    ("require-scopes", True, "Thie enables enforcement of permission checking of scopes."),
     ("show_django_message_sdk", True, "This enables the Django message in the developer sandbox home."),
-    ("show_testclient_link", True, ""),
-    ("signup", True, ""),
+    ("show_testclient_link", True, "This controls the display of the test client link from the main page."),
+    ("signup", True, "This enables signup related URLs and code paths. Not active in prod."),
     ("splunk_monitor", False, "This is used in other environments to ensure splunk forwarder is running."),
-    ("testclient_v2", True, ""),
-    ("wellknown_applications", True, ""),
+    ("testclient_v2", True, "This enables the v2 auth links in the test client"),
+    ("wellknown_applications", True, "This enables the /.well-known/applications end-point. Active in prod, but not in sbx/test."),
 )
 
 WAFFLE_FEATURE_FLAGS = (

--- a/apps/core/management/commands/create_test_feature_switches.py
+++ b/apps/core/management/commands/create_test_feature_switches.py
@@ -4,16 +4,19 @@ from waffle.models import Switch
 from apps.core.models import Flag
 
 WAFFLE_FEATURE_SWITCHES = (
-    ("outreach_email", True),
-    ("wellknown_applications", True),
-    ("login", True),
-    ("signup", True),
-    ("require-scopes", True),
-    ("testclient_v2", True),
-    ("enable_testclient", True),
-    ("show_testclient_link", True),
-    ("interim-prod-access", True),
-    ("enable_swaggerui", True),
+    ("enable_swaggerui", True, ""),
+    ("enable_testclient", True, ""),
+    ("expire_grant_endpoint", True, "This enables the /v<1/2>/o/expire_authenticated_user/<patient_id>/ endpoint"),
+    ("interim-prod-access", True, ""),
+    ("login", True, ""),
+    ("outreach_email", True, ""),
+    ("require-scopes", True, ""),
+    ("show_django_message_sdk", True, "This enables the Django message in the developer sandbox home."),
+    ("show_testclient_link", True, ""),
+    ("signup", True, ""),
+    ("splunk_monitor", False, "This is used in other environments to ensure splunk forwarder is running."),
+    ("testclient_v2", True, ""),
+    ("wellknown_applications", True, ""),
 )
 
 WAFFLE_FEATURE_FLAGS = (
@@ -30,7 +33,7 @@ class Command(BaseCommand):
                 Switch.objects.get(name=switch[0])
                 self._log("Feature switch already exists: %s" % (str(switch)))
             except Switch.DoesNotExist:
-                Switch.objects.create(name=switch[0], active=switch[1])
+                Switch.objects.create(name=switch[0], active=switch[1], note=switch[2])
                 self._log("Feature switch created: %s" % (str(switch)))
 
         # Create feature flags for testing in local development


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-3346](https://jira.cms.gov/browse/BB2-3346)
[BB2-2871](https://jira.cms.gov/browse/BB2-2871)

### What Does This PR Do?

This PR adds some waffle switches to our local environment, so that testing locally more closely mimics the behavior we would see in TEST/SBX/PROD. While editing these switches, I also added support for notes to be included in the automatically locally created switches, and put them in alphabetical order.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

- Are any of these switches ones that we should omit from local envs for some reason?
- Are these descriptions helpful enough to count as documentation?

### Validation

Navigate to http://localhost:8000/admin/waffle/switch in your local environment, and compare to the same page in the other environments.
Confirm that http://localhost:8000/home shows the Spanish language feature message. Optionally, disable [show_django_message_sdk](http://localhost:8000/admin/waffle/switch/12/change/?_changelist_filters=o%3D1) and see that the message goes away.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
