### PR TITLE
BB2-3497: fix auth version redirects

### DIFF
--- a/apps/dot_ext/urls.py
+++ b/apps/dot_ext/urls.py
@@ -7,7 +7,7 @@ app_name = "oauth2_provider"
 
 
 base_urlpatterns = [
-    path("authorize/", views.AuthorizationView.as_view(), name="authorize"),
+    path("authorize/", views.AuthorizationView.as_view(version=2), name="authorize"),
     re_path(
         r"^authorize/(?P<uuid>[\w-]+)/$",
         views.ApprovalView.as_view(),

--- a/apps/dot_ext/urls.py
+++ b/apps/dot_ext/urls.py
@@ -10,7 +10,7 @@ base_urlpatterns = [
     path("authorize/", views.AuthorizationView.as_view(version=2), name="authorize"),
     re_path(
         r"^authorize/(?P<uuid>[\w-]+)/$",
-        views.ApprovalView.as_view(),
+        views.ApprovalView.as_view(version=2),
         name="authorize-instance",
     ),
     path("token/", views.TokenView.as_view(), name="token"),

--- a/apps/mymedicare_cb/tests/test_callback_slsx.py
+++ b/apps/mymedicare_cb/tests/test_callback_slsx.py
@@ -252,7 +252,7 @@ class MyMedicareSLSxBlueButtonClientApiUserInfoTest(BaseApiTest):
             self.assertIn("client_id=test", response.url)
             self.assertIn("redirect_uri=test.com", response.url)
             self.assertIn("response_type=token", response.url)
-            self.assertIn("http://www.google.com/v1/o/authorize/", response.url)
+            self.assertIn("http://www.google.com/v2/o/authorize/", response.url)
             # assert login
             self.assertNotIn("_auth_user_id", self.client.session)
 

--- a/apps/mymedicare_cb/views.py
+++ b/apps/mymedicare_cb/views.py
@@ -84,7 +84,7 @@ def authenticate(request):
 
 
 @never_cache
-def callback(request, version=1):
+def callback(request, version=2):
     try:
         authenticate(request)
     except ValidationError as e:

--- a/apps/testclient/views.py
+++ b/apps/testclient/views.py
@@ -178,7 +178,7 @@ def test_links(request, **kwargs):
     if 'token' in request.session:
         return render(request, HOME_PAGE,
                       context={"session_token": request.session['token'],
-                               "api_ver": request.session.get('api_ver', 'v1')})
+                               "api_ver": request.session.get('api_ver', 'v2')})
     else:
         return render(request, HOME_PAGE, context={"session_token": None})
 

--- a/docker-compose/run_selenium_tests_remote.sh
+++ b/docker-compose/run_selenium_tests_remote.sh
@@ -118,12 +118,12 @@ export USE_NEW_PERM_SCREEN
 export USE_MSLSX=false
 
 # stop all before run selenium remote tests
-docker-compose -f docker-compose.selenium.remote.yml down --remove-orphans
-docker-compose -f docker-compose.selenium.remote.yml run selenium-remote-tests bash -c "SELENIUM_GRID=${SELENIUM_GRID} pytest ${PYTEST_SHOW_TRACE_OPT} ${TESTS_LIST}"
+docker compose -f docker-compose.selenium.remote.yml down --remove-orphans
+docker compose -f docker-compose.selenium.remote.yml run selenium-remote-tests bash -c "SELENIUM_GRID=${SELENIUM_GRID} pytest ${PYTEST_SHOW_TRACE_OPT} ${TESTS_LIST}"
 
 # Stop containers after use
 echo_msg
 echo_msg "Stopping containers..."
 echo_msg
 
-docker-compose -f docker-compose.selenium.remote.yml stop
+docker compose -f docker-compose.selenium.remote.yml stop


### PR DESCRIPTION

**JIRA Ticket:**
[BB2-3497](https://jira.cms.gov/browse/BB2-3497)

### What Does This PR Do?

This PR makes all auth requests hit the v2 callback. This is a simple change that doesn't rely on SLS, but helps us eliminate potential confusion caused by an apparent version downgrade in auth and prevent potential forking of auth paths and strategies. Since v1 and v2 auth are the same, this is mostly aimed at preventing confusion among our users, simplifying the logs, and preventing potential forking if we make future changes to the v2 auth path that are not reflected for users starting with v1.

### Validation

To validate, run locally and use the test client to authorize. After auth, api version should read v2, regardless

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
