### PR TITLE
BB2-3796: Allow POST in auth requests

### DIFF
--- a/apps/capabilities/management/commands/create_blue_button_scopes.py
+++ b/apps/capabilities/management/commands/create_blue_button_scopes.py
@@ -307,6 +307,3 @@ class Command(BaseCommand):
         create_coverage_read_search_capability(g, fhir_prefix)
         create_launch_capability(g, fhir_prefix)
         create_openid_capability(g)
-
-        call_command('loaddata', 'internal_application_labels.json')
-

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -53,7 +53,6 @@ def get_grant_expiration(data_access_type):
     pass
 
 
-@method_decorator(csrf_exempt, name="dispatch")
 class AuthorizationView(DotAuthorizationView):
     """
     Override the base authorization view from dot to
@@ -299,7 +298,6 @@ class ApprovalView(AuthorizationView):
 @method_decorator(csrf_exempt, name="dispatch")
 class TokenView(DotTokenView):
     @method_decorator(sensitive_post_parameters("password"))
-    @method_decorator(csrf_exempt)
     def post(self, request, *args, **kwargs):
         try:
             app = validate_app_is_active(request)

--- a/apps/mymedicare_cb/tests/test_callback_slsx.py
+++ b/apps/mymedicare_cb/tests/test_callback_slsx.py
@@ -174,6 +174,7 @@ class MyMedicareSLSxBlueButtonClientApiUserInfoTest(BaseApiTest):
                 "client_id": "bad",
                 "redirect_uri": "http://test.com",
                 "response_type": "code",
+                "state": "1234567890",
             },
         )
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
@@ -184,6 +185,7 @@ class MyMedicareSLSxBlueButtonClientApiUserInfoTest(BaseApiTest):
             "scope": ["capability-a"],
             "expires_in": 86400,
             "allow": True,
+            "state": "1234567890",
         }
         response = self.client.post(auth_uri, data=payload)
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
@@ -196,9 +198,20 @@ class MyMedicareSLSxBlueButtonClientApiUserInfoTest(BaseApiTest):
                 "client_id": application.client_id,
                 "redirect_uri": "http://test.com",
                 "response_type": "code",
+                "state": "1234567890",
             },
         )
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
+        # Test without state
+        response = self.client.post(
+            auth_uri,
+            data={
+                "client_id": application.client_id,
+                "redirect_uri": "http://test.com",
+                "response_type": "code",
+            },
+        )
+        self.assertEqual(status.HTTP_401_UNAUTHORIZED, response.status_code)
 
     def test_callback_url_success(self):
         # create a state


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3796](https://jira.cms.gov/browse/BB2-3796)

### What Does This PR Do?

Adds support for making POST authenticate requests, while requiring state.  


### Validation

Tests. You can walk through the steps [here](https://bluebutton.cms.gov/developers/#authorization) to test, but make your request to `/v2/o/authorize` a POST request with the data submitted using -d in your curl request instead of putting it in a query string. NB: If you don't include a state value, you will receive a 401 response. 

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [x] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
