### PR TITLE
BB2-3889: Consolidate scopes during auth flow, set v2 scopes to default.

### DIFF
--- a/apps/accounts/fixtures/scopes.json
+++ b/apps/accounts/fixtures/scopes.json
@@ -100,7 +100,7 @@
             "group": 5,
             "description": "Patient FHIR Resource",
             "protected_resources": "[\n \n [\n    \"GET\",\n   \"/v[12]/fhir/Patient[/?].*$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -112,7 +112,7 @@
             "group": 5,
             "description": "Patient FHIR Resource",
             "protected_resources": "[\n  [\n    \"GET\",\n   \"/v[12]/fhir/Patient[/]?$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -124,7 +124,7 @@
             "group": 5,
             "description": "Patient FHIR Resource",
             "protected_resources": "[\n  [\n    \"GET\",\n   \"/v[12]/fhir/Patient[/]?$\"\n  ],\n [\n    \"GET\",\n   \"/v[12]/fhir/Patient[/?].*$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -136,7 +136,7 @@
             "group": 5,
             "description": "ExplanationOfBenefit FHIR Resource",
             "protected_resources": "[\n \n [\n    \"GET\",\n   \"/v[12]/fhir/ExplanationOfBenefit[/?].*$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -148,7 +148,7 @@
             "group": 5,
             "description": "ExplanationOfBenefit FHIR Resource",
             "protected_resources": "[\n  [\n    \"GET\",\n   \"/v[12]/fhir/ExplanationOfBenefit[/]?$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -160,7 +160,7 @@
             "group": 5,
             "description": "ExplanationOfBenefit FHIR Resource",
             "protected_resources": "[\n  [\n    \"GET\",\n   \"/v[12]/fhir/ExplanationOfBenefit[/]?$\"\n  ],\n  [\n    \"GET\",\n   \"/v[12]/fhir/ExplanationOfBenefit[/?].*$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -172,7 +172,7 @@
             "group": 5,
             "description": "Coverage FHIR Resource",
             "protected_resources": "[\n \n [\n    \"GET\",\n   \"/v[12]/fhir/Coverage[/?].*$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {
@@ -184,7 +184,7 @@
             "group": 5,
             "description": "Coverage FHIR Resource",
             "protected_resources": "[\n  [\n    \"GET\",\n   \"/v[12]/fhir/Coverage[/]?$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
         {
@@ -196,7 +196,7 @@
             "group": 5,
             "description": "Coverage FHIR Resource",
             "protected_resources": "[\n  [\n    \"GET\",\n   \"/v[12]/fhir/Coverage[/]?$\"\n  ],\n  [\n    \"GET\",\n   \"/v[12]/fhir/Coverage[/?].*$\"\n  ]\n]",
-            "default": "False"
+            "default": "True"
         }
     },
     {

--- a/apps/capabilities/admin.py
+++ b/apps/capabilities/admin.py
@@ -5,5 +5,5 @@ from .models import ProtectedCapability
 
 @admin.register(ProtectedCapability)
 class ProtectedCapabilityAdmin(admin.ModelAdmin):
-    list_display = ("title", "slug", "group")
+    list_display = ("title", "slug", "group", "default")
     search_fields = ("title", "slug", "group")

--- a/apps/capabilities/management/commands/create_blue_button_scopes.py
+++ b/apps/capabilities/management/commands/create_blue_button_scopes.py
@@ -89,7 +89,6 @@ def create_patient_read_capability(group, fhir_prefix, title="Read my general pa
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -108,7 +107,6 @@ def create_patient_search_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -129,7 +127,6 @@ def create_patient_read_search_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -161,7 +158,6 @@ def create_eob_read_capability(group, fhir_prefix, title="Read my Medicare claim
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -176,7 +172,6 @@ def create_eob_search_capability(group, fhir_prefix, title="Search my Medicare c
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -194,7 +189,6 @@ def create_eob_read_search_capability(group, fhir_prefix, title="Read and search
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -228,7 +222,6 @@ def create_coverage_read_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -246,7 +239,6 @@ def create_coverage_search_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 
@@ -265,7 +257,6 @@ def create_coverage_read_search_capability(group,
                                                title=title,
                                                description=description,
                                                slug=smart_scope_string,
-                                               default=False,
                                                protected_resources=json.dumps(pr, indent=4))
     return c
 

--- a/apps/dot_ext/tests/test_scopes.py
+++ b/apps/dot_ext/tests/test_scopes.py
@@ -78,3 +78,35 @@ class TestScopesBackendClass(BaseApiTest):
         # retrieve the list of the scopes available for the application
         default_scopes = CapabilitiesScopes().get_default_scopes(application=application)
         assert default_scopes == []
+
+    def test_condense_scopes(self):
+        """
+        Test that v2 scopes get properly condensed
+        """
+        scopes = [
+            'patient/Patient.r',
+            'patient/Patient.s',
+            'patient/Patient.rs',
+            'patient/Coverage.s',
+            'patient/Coverage.rs',
+            'patient/ExplanationOfBenefit.r',
+            'patient/ExplanationOfBenefit.s'
+        ]
+        condensed_scopes = CapabilitiesScopes().condense_scopes(scopes)
+        assert len(condensed_scopes) == 3
+        assert 'patient/Patient.rs' in condensed_scopes
+        assert 'patient/Coverage.rs' in condensed_scopes
+        assert 'patient/ExplanationOfBenefit.rs' in condensed_scopes
+        scopes = [
+            'patient/Patient.r',
+            'patient/Coverage.s',
+            'patient/Coverage.rs',
+            'patient/ExplanationOfBenefit.s',
+            'profile'
+        ]
+        condensed_scopes = CapabilitiesScopes().condense_scopes(scopes)
+        assert len(condensed_scopes) == 4
+        assert 'patient/Patient.r' in condensed_scopes
+        assert 'patient/Coverage.rs' in condensed_scopes
+        assert 'patient/ExplanationOfBenefit.s' in condensed_scopes
+        assert 'profile' in condensed_scopes


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3889](https://jira.cms.gov/browse/BB2-3889)

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
-->
This PR does the last touches on the v2 scopes before we enable them in our main environments. This includes:

- Making the v2 scopes default in the scripts and json files that populate protected capabilities
- Adding a condense function that will consolidate and remove redundant v2 scopes
- Adding the default label to the protected capabilities view in django admin

There's also a minor refactor to extract a function to remove demographic scopes, since that was being done in a few places.

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

Are there any other things that we should do before rolling these scopes out in prod?

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->
You can test the new function by running `docker compose exec web python runtests.py apps.dot_ext.tests.test_scopes.TestScopesBackendClass.test_condense_scopes`.

Aside from that, go through the auth flow both with different combinations of scope values. You can start from the [test client](http://localhost:8000/testclient/authorize-link-v2?pkce=true). From there, some different cases to try:

- Use the basic auth link
- Add `&scope=patient%2FPatient.r%20patient%2FCoverage.r%20patient%2FExplanationOfBenefit.r` to the basic auth link
- Add `&scope=patient%2FPatient.r%20patient%Patient.s` to the basic auth link
- Add other combinations to the basic auth link, with and without demographic access granted on the permissions screen

Using the test client makes it easy to see the resulting token, since the callback url will automatically get the token and show the details on the screen. Verify that you get reasonable scopes back from the different combinations of requested scopes.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
