### PR TITLE
jimfuqian/BB2-3887 Added search parameter _tag for EOB

### DIFF
--- a/apps/core/management/commands/create_test_feature_switches.py
+++ b/apps/core/management/commands/create_test_feature_switches.py
@@ -16,6 +16,7 @@ WAFFLE_FEATURE_SWITCHES = (
     ("splunk_monitor", False, "This is used in other environments to ensure splunk forwarder is running."),
     ("testclient_v2", True, "This enables the v2 auth links in the test client"),
     ("wellknown_applications", True, "This enables the /.well-known/applications end-point. Active in prod, but not in sbx/test."),
+    ("bfd_v3_connectathon", True, "This enables the bfd v3 features for connectathon demo"),
 )
 
 WAFFLE_FEATURE_FLAGS = (

--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -4,6 +4,7 @@ from django.test.client import Client
 from django.urls import reverse
 from httmock import all_requests, HTTMock
 from oauth2_provider.models import get_access_token_model
+from waffle.testutils import override_switch
 
 from apps.test import BaseApiTest
 
@@ -154,12 +155,15 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
             for r in response.json()['entry']:
                 self._assertHasC4BBIdentifier(r['resource'], C4BB_SYSTEM_TYPES['IDTYPE'], v2)
 
+    @override_switch('bfd_v3_connectathon', active=True)
     def test_search_eob_by_parameter_tag(self):
         self._search_eob_by_parameter_tag(False)
 
+    @override_switch('bfd_v3_connectathon', active=True)
     def test_search_eob_by_parameter_tag_v2(self):
         self._search_eob_by_parameter_tag(True)
 
+    @override_switch('bfd_v3_connectathon', active=True)
     def _search_eob_by_parameter_tag(self, v2=False):
         # create the user
         first_access_token = self.create_token('John', 'Smith')
@@ -174,7 +178,7 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
             self.assertIn("https://fhir.backend.bluebutton.hhsdevcloud.us/{}/fhir/ExplanationOfBenefit/".format(ver), req.url)
             self.assertIn("_format=application%2Fjson%2Bfhir", req.url)
             # parameters encoded in prepared request's body
-            self.assertTrue(("_tag=ADJUDICATED" in req.body) or ("_tag=PARTIALLY-ADJUDICATED" in req.body))
+            self.assertTrue(("_tag=Adjudicated" in req.body) or ("_tag=PartiallyAdjudicated" in req.body))
 
             return {
                 'status_code': 200,
@@ -190,26 +194,26 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
                 'status_code': 200,
                 'content': get_response_json("eob_search_pt_{}".format(ver)),
             }
-        # Test _tag with valid parameter value e.g. ADJUDICATED, PARTIALLY-ADJUDICATED
+        # Test _tag with valid parameter value e.g. Adjudicated, PartiallyAdjudicated
         with HTTMock(catchall_w_tag_qparam):
             response = self.client.get(
                 reverse('bb_oauth_fhir_eob_search' if not v2 else 'bb_oauth_fhir_eob_search_v2'),
-                {'_tag': 'ADJUDICATED'},
+                {'_tag': 'Adjudicated'},
                 Authorization="Bearer %s" % (first_access_token))
             # just check for 200 is sufficient
             self.assertEqual(response.status_code, 200)
 
-        # Test _tag with invalid parameter value e.g.: ADJUDIACTED-TYPO
+        # Test _tag with invalid parameter value e.g.: Adjudiacted-Typo
         with HTTMock(catchall):
             response = self.client.get(
                 reverse('bb_oauth_fhir_eob_search' if not v2 else 'bb_oauth_fhir_eob_search_v2'),
-                {'_tag': 'ADJUDIACTED-TYPO'},
+                {'_tag': 'Adjudiacted-Typo'},
                 Authorization="Bearer %s" % (first_access_token))
 
             content = json.loads(response.content.decode("utf-8"))
             self.assertTrue(content['detail'].startswith("Invalid _tag value ("))
-            self.assertTrue(content['detail'].endswith("'PARTIALLY-ADJUDICATED' or 'ADJUDICATED' expected."))
-            self.assertTrue('ADJUDIACTED-TYPO' in content['detail'])
+            self.assertTrue(content['detail'].endswith("'PartiallyAdjudicated' or 'Adjudicated' expected."))
+            self.assertTrue('Adjudiacted-Typo' in content['detail'])
             self.assertEqual(response.status_code, 400)
 
     def test_search_eob_by_parameters_request(self):
@@ -225,22 +229,6 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
         ac.scope = 'patient/ExplanationOfBenefit.read'
         ac.save()
         ver = 'v1' if not v2 else 'v2'
-
-        @all_requests
-        def catchall_w_tag_qparam(url, req):
-            self.assertIn("https://fhir.backend.bluebutton.hhsdevcloud.us/{}/fhir/ExplanationOfBenefit/".format(ver), req.url)
-            self.assertIn("_format=application%2Fjson%2Bfhir", req.url)
-
-            tag_val = req.query_params.getlist('_tag')
-            for v in tag_val:
-                self.assertIn(v,
-                              ['PARTIALLY-ADJUDICATED', 'ADJUDICATED'],
-                              msg="Bad _tag value {} found in call to backend".format(v))
-
-            return {
-                'status_code': 200,
-                'content': get_response_json("eob_search_pt_{}".format(ver)),
-            }
 
         @all_requests
         def catchall(url, req):

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -1,3 +1,4 @@
+# import waffle
 from voluptuous import (
     Required,
     All,
@@ -110,8 +111,8 @@ class SearchViewExplanationOfBenefit(SearchView):
     def validate_tag():
         def validator(value):
             for v in value:
-                if not (v in ["ADJUDICATED", "PARTIALLY-ADJUDICATED"]):
-                    msg = f"Invalid _tag value (='{v}'), 'PARTIALLY-ADJUDICATED' or 'ADJUDICATED' expected."
+                if not (v in ["Adjudicated", "PartiallyAdjudicated"]):
+                    msg = f"Invalid _tag value (='{v}'), 'PartiallyAdjudicated' or 'Adjudicated' expected."
                     raise Invalid(msg)
             return value
         return validator
@@ -145,11 +146,17 @@ class SearchViewExplanationOfBenefit(SearchView):
     REGEX_SERVICE_DATE_VALUE = r'^((lt)|(le)|(gt)|(ge)).+'
 
     # Add type parameter to schema only for EOB
+    # if waffle.switch_is_active('bfd_v3_connectathon'):
     QUERY_SCHEMA = {**SearchView.QUERY_SCHEMA,
                     'type': Match(REGEX_TYPE_VALUES_LIST, msg="the type parameter value is not valid"),
                     'service-date': [Match(REGEX_SERVICE_DATE_VALUE, msg="the service-date operator is not valid")],
                     '_tag': validate_tag()
                     }
+    # else:
+    #     QUERY_SCHEMA = {**SearchView.QUERY_SCHEMA,
+    #                     'type': Match(REGEX_TYPE_VALUES_LIST, msg="the type parameter value is not valid"),
+    #                     'service-date': [Match(REGEX_SERVICE_DATE_VALUE, msg="the service-date operator is not valid")],
+    #                     }
 
     def __init__(self, version=1):
         super().__init__(version)
@@ -173,6 +180,7 @@ class SearchViewExplanationOfBenefit(SearchView):
         schema = Schema(
             getattr(self, "QUERY_SCHEMA", {}),
             extra=REMOVE_EXTRA)
+        # if waffle.switch_is_active('bfd_v3_connectathon'):
         # _tag if presents, is a string value
         params['_tag'] = request.query_params.getlist('_tag')
         return schema(params)


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-3887](https://jira.cms.gov/browse/BB2-3887)

Add EOB search parameter _tag

### What Does This PR Do?

1. Added EOB search parameter _tag to the currently supported parameters e.g. _lastUpdated, _service_date etc.
2. Customized validator for _tag where more accurate validation error can be achieved, [Python data validator: voluptuous](https://pypi.org/project/voluptuous/)


<!--
Add detailed description & discussion of changes here.
-->

### What Should Reviewers Watch For?

Verify that the _tag parameter is only applicable to EOB search:
EOB read won't have it (parameter validator policy for extra : removed)
Patient read/search won't have it (parameter validator policy for extra : removed)
Coverage read/search won't have it (parameter validator policy for extra : removed)

Check parameter value validation:
ADJUDICATED, PARTIALLY-ADJUDICATED are only valid values, other value will be rejected with a detailed validation error message.

A feature switch 'bfd_v3_connectathon' introduced to guard the new _tag support code, and it is set to True in a local setup.

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

1. Check out PR and spin up a local BB2 (follow readme)
2. Create an app with postman callback URL added to the app's callback URLs
3. Best tested and verified with postman (follow postman BB2 conf page)
4. Set up postman auth pointing to the app registered at step 2
5. Do authorize - medicare.gov login, grant data access etc., end up with a token and choose use token
6. Now perform the testing and verifying with FHIR endpoints:
7. EOB happy case: GET {{baseUrl}}/v2/fhir/ExplanationOfBenefit/?_tag=PARTIALLY-ADJUDICATED, should see 200 response with claims bundle
8. EOB un-happy GET {{baseUrl}}/v2/fhir/ExplanationOfBenefit/?_tag=PARTIALLY-ADJUDIACTED-TYPO, should see validation error: 
![image](https://github.com/user-attachments/assets/4258827d-0f97-4d0b-9e18-20286953a39b)
9. Similarly test and verify validation behavior with EOB read and Patient, Coverage endpoints

Verify that CI check pass (including newly added unit test for _tag parameter support (adding test coverage WIP)

Locally, after spin up a bb2 server, bash into docker and run the new tests like:

python runtests.py apps.fhir.bluebutton.tests.test_fhir_resources_read_search_w_validation.FHIRResourcesReadSearchTest.test_search_eob_by_parameter_tag

python runtests.py apps.fhir.bluebutton.tests.test_fhir_resources_read_search_w_validation.FHIRResourcesReadSearchTest.test_search_eob_by_parameter_tag_v2



<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
