### PR TITLE
Revert certificate verification changes.

### DIFF
--- a/apps/health/checks.py
+++ b/apps/health/checks.py
@@ -34,7 +34,7 @@ def bfd_fhir_dataserver(v2=False):
     r = requests.get(target_url,
                      params={"_format": "json"},
                      cert=backend_connection.certs(),
-                     verify=True,
+                     verify=False,
                      timeout=5)
     try:
         r.raise_for_status()


### PR DESCRIPTION
Hotfix to revert certificate verification changes for bfd healthchecks. 

This change was made to silence a snyk report, but may be necessary for our sandbox healthchecks.