### PR TITLE
BB2-4777 fix failing POST authorization requests

### DIFF
--- a/apps/dot_ext/tests/test_authorization.py
+++ b/apps/dot_ext/tests/test_authorization.py
@@ -1244,6 +1244,7 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
         # Create an instance of the view
         view_instance = AuthorizationView()
         view_instance.request = request
+        view_instance.application = fake_application
 
         with self.assertRaises(AccessDeniedTokenCustomError):
             view_instance.validate_v3_authorization_request()

--- a/apps/dot_ext/tests/test_authorization.py
+++ b/apps/dot_ext/tests/test_authorization.py
@@ -1575,6 +1575,5 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
                 }
                 response = (getattr(self.client, method))(response['Location'], data=payload)
 
-                # TODO should we use self.assertRedirects here?
                 self.assertEqual(response.status_code, HTTPStatus.FOUND)
                 self.assertTrue(response.url.startswith('/mymedicare/login'))

--- a/apps/dot_ext/tests/test_authorization.py
+++ b/apps/dot_ext/tests/test_authorization.py
@@ -1526,8 +1526,6 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
         """
         Ensure the authorize endpoint works across versions and methods.
         """
-        # TODO a lot of this is not DRY with other tests
-
         redirect_uri = 'com.custom.bluebutton://example.it'
         self._create_user('anna', '123456')
         capability_a = self._create_capability('Capability A', [])
@@ -1544,16 +1542,17 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
         # Seems to be that without being logged in, we get a redirect to
         # /mymedicare/login, which would I think then go to the medicare.gov login
         # screen. But why does the user being logged in to bluebutton bypass this?
+        # TODO check that this is in fact the behavior and I didn't do anything else
+        # to change the behavior
         # request = HttpRequest()
         # self.client.login(request=request, username='anna', password='123456')
 
-        # TODO looks kinda random, anything special about it?
+        # TODO move to constant?
         code_challenge = 'sZrievZsrYqxdnu2NVD603EiYBM18CuzZpwB-pOSZjo'
 
         # TODO pytest.mark.parameterize
         for method in ['get', 'post']:
             for version in Versions.supported_versions():
-                print(method, version)
                 payload = {
                     'client_id': application.client_id,
                     'response_type': 'code',
@@ -1575,14 +1574,7 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
                     'code_challenge_method': CODE_CHALLENGE_METHOD_S256,
                 }
                 response = (getattr(self.client, method))(response['Location'], data=payload)
-                print(response)
-                print(response.content)
 
+                # TODO should we use self.assertRedirects here?
                 self.assertEqual(response.status_code, HTTPStatus.FOUND)
                 self.assertTrue(response.url.startswith('/mymedicare/login'))
-                # self.assertRedirects(
-                #     response,
-                #     expected_url='/mymedicare/login',
-                #     status_code=302,
-                #     fetch_redirect_response=False,
-                # )

--- a/apps/dot_ext/tests/test_authorization.py
+++ b/apps/dot_ext/tests/test_authorization.py
@@ -1413,20 +1413,18 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
     @override_switch('v3_endpoints', active=True)
     def test_valid_uuid_authorize_call(self):
         """BB2-4326: Ensure a 302 is thrown if a valid UUID is passed to an authorize endpoint"""
+        app = self._create_application('an app')
         auth_uri_v1 = reverse('oauth2_provider:authorize-instance', args=[uuid.uuid4()])
         auth_uri_v2 = reverse('oauth2_provider_v2:authorize-instance-v2', args=[uuid.uuid4()])
         auth_uri_v3 = reverse('oauth2_provider_v3:authorize-instance-v3', args=[uuid.uuid4()])
 
-        response_v1 = self.client.get(auth_uri_v1)
-        response_v2 = self.client.get(auth_uri_v2)
-        response_v3 = self.client.get(auth_uri_v3)
+        response_v1 = self.client.get(auth_uri_v1, data={'client_id': app.client_id})
+        response_v2 = self.client.get(auth_uri_v2, data={'client_id': app.client_id})
+        response_v3 = self.client.get(auth_uri_v3, data={'client_id': app.client_id})
 
         assert response_v1.status_code == HTTPStatus.FOUND
         assert response_v2.status_code == HTTPStatus.FOUND
-        # The behavior is different for v3, as we check v3 authorize calls to see if the application is in
-        # the v3_early_adopter flag (part of BB2-4250). Because all of the mocks are not included in this test
-        # such that the authorize call will return a 302 for v3, v3 in this test throws a 403
-        assert response_v3.status_code == HTTPStatus.FORBIDDEN
+        assert response_v3.status_code == HTTPStatus.FOUND
 
     @patch(
         'apps.mymedicare_cb.models.match_fhir_id',

--- a/apps/dot_ext/tests/test_authorization.py
+++ b/apps/dot_ext/tests/test_authorization.py
@@ -1521,9 +1521,9 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
         self.assertEqual(response.json()['message'], 'Failed to retrieve data from data source.')
 
     @override_switch('v3_endpoints', active=True)
-    def test_authorization_endpoint_across_versions(self):
+    def test_authorization_endpoint_across_versions_and_methods(self):
         """
-        Ensure the authorize endpoint works across versions.
+        Ensure the authorize endpoint works across versions and methods.
         """
         # TODO a lot of this is not DRY with other tests
 

--- a/apps/dot_ext/tests/test_authorization.py
+++ b/apps/dot_ext/tests/test_authorization.py
@@ -1519,3 +1519,69 @@ class TestAuthorizeWithCustomScheme(BaseApiTest):
 
         self.assertEqual(response.status_code, HTTPStatus.BAD_GATEWAY)
         self.assertEqual(response.json()['message'], 'Failed to retrieve data from data source.')
+
+    @override_switch('v3_endpoints', active=True)
+    def test_authorization_endpoint_across_versions(self):
+        """
+        Ensure the authorize endpoint works across versions.
+        """
+        # TODO a lot of this is not DRY with other tests
+
+        redirect_uri = 'com.custom.bluebutton://example.it'
+        self._create_user('anna', '123456')
+        capability_a = self._create_capability('Capability A', [])
+        application = self._create_application(
+            'an app',
+            grant_type=Application.GRANT_AUTHORIZATION_CODE,
+            client_type=Application.CLIENT_CONFIDENTIAL,
+            redirect_uris=redirect_uri,
+        )
+        application.scope.add(capability_a)
+        application.save()
+
+        # TODO this doesn't seem to be necessary, but its in the other tests. why?
+        # Seems to be that without being logged in, we get a redirect to
+        # /mymedicare/login, which would I think then go to the medicare.gov login
+        # screen. But why does the user being logged in to bluebutton bypass this?
+        # request = HttpRequest()
+        # self.client.login(request=request, username='anna', password='123456')
+
+        # TODO looks kinda random, anything special about it?
+        code_challenge = 'sZrievZsrYqxdnu2NVD603EiYBM18CuzZpwB-pOSZjo'
+
+        # TODO pytest.mark.parameterize
+        for method in ['get', 'post']:
+            for version in Versions.supported_versions():
+                print(method, version)
+                payload = {
+                    'client_id': application.client_id,
+                    'response_type': 'code',
+                    'redirect_uri': redirect_uri,
+                    'code_challenge': code_challenge,
+                    'code_challenge_method': CODE_CHALLENGE_METHOD_S256,
+                }
+                # TODO this first request might not be necessary?
+                response = (getattr(self.client, method))(f'/v{version}/o/authorize', data=payload)
+                payload = {
+                    'client_id': application.client_id,
+                    'response_type': 'code',
+                    'redirect_uri': redirect_uri,
+                    'scope': ['capability-a'],
+                    'expires_in': 86400,
+                    'allow': True,
+                    'state': '0123456789abcdef',
+                    'code_challenge': code_challenge,
+                    'code_challenge_method': CODE_CHALLENGE_METHOD_S256,
+                }
+                response = (getattr(self.client, method))(response['Location'], data=payload)
+                print(response)
+                print(response.content)
+
+                self.assertEqual(response.status_code, HTTPStatus.FOUND)
+                self.assertTrue(response.url.startswith('/mymedicare/login'))
+                # self.assertRedirects(
+                #     response,
+                #     expected_url='/mymedicare/login',
+                #     status_code=302,
+                #     fetch_redirect_response=False,
+                # )

--- a/apps/dot_ext/utils.py
+++ b/apps/dot_ext/utils.py
@@ -199,7 +199,7 @@ def get_application_from_data(request):
     return None
 
 
-def validate_app_is_active(request: HttpRequest) -> Application:
+def validate_app_is_active(request: HttpRequest) -> Application | None:
     """
     Utility function to check that an application is an active, valid application.
     This method will pull the application from the request and then check the active flag and the

--- a/apps/dot_ext/utils.py
+++ b/apps/dot_ext/utils.py
@@ -199,7 +199,7 @@ def get_application_from_data(request):
     return None
 
 
-def validate_app_is_active(request: HttpRequest) -> Application | None:
+def validate_app_is_active(request: HttpRequest) -> Application:
     """
     Utility function to check that an application is an active, valid application.
     This method will pull the application from the request and then check the active flag and the
@@ -213,7 +213,7 @@ def validate_app_is_active(request: HttpRequest) -> Application | None:
         InvalidRequestError: Missing refresh token parameter
 
     Returns:
-        Model: Application model or None
+        Model: Application model
     """
     app = get_application_from_meta(request)
     if not app:
@@ -223,11 +223,12 @@ def validate_app_is_active(request: HttpRequest) -> Application | None:
     if request.POST.get('grant_type') == 'client_credentials':
         if not request.POST.get('client_assertion'):
             raise InvalidRequestError('Missing client_assertion for client_credentials grant')
-        if not app:
-            raise InvalidClientError('App id failed')
+
+    if not app:
+        raise InvalidClientError('App id failed')
 
     # revoked access and expired auth period to a 401 error
-    if app and app.active:
+    if app.active:
         # Is this for a token refresh request?
         post_grant_type = request.POST.get('grant_type', None)
         if post_grant_type == 'refresh_token':
@@ -270,7 +271,7 @@ def validate_app_is_active(request: HttpRequest) -> Application | None:
                     description='Missing refresh token parameter',
                     status_code=HTTPStatus.BAD_REQUEST,
                 )
-    elif app and not app.active:
+    else:
         raise InvalidClientError(
             description=APPLICATION_TEMPORARILY_INACTIVE.format(app.name),
             status_code=HTTPStatus.FORBIDDEN,

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -169,6 +169,8 @@ class AuthorizationView(DotAuthorizationView):
 
     def __init__(self, version=1):
         self.version = version
+        # TODO should we add this so every instance at least has the attribute?
+        # self.application = None
         super().__init__()
 
     def _get_param(self, request, key, default=None):

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -226,20 +226,6 @@ class AuthorizationView(DotAuthorizationView):
         initially create an AuthFlowUuid object for authorization
         flow tracing in logs.
         """
-        path_info = self.request.__dict__.get('path_info')
-        version = get_api_version_number_from_url(path_info)
-        # If it is not version 3, we don't need to check anything, just return
-        if version == Versions.V3:
-            try:
-                self.validate_v3_authorization_request()
-            except AccessDeniedError:
-                return JsonResponse(
-                    {
-                        'status_code': HTTPStatus.FORBIDDEN,
-                        'message': 'Unable to verify permission',
-                    },
-                    status=HTTPStatus.FORBIDDEN,
-                )
 
         # TODO: Should the client_id match a valid application here before continuing, instead of after matching to FHIR_ID?
         if not kwargs.get('is_subclass_approvalview', False):
@@ -257,6 +243,22 @@ class AuthorizationView(DotAuthorizationView):
                 },
                 status=error.status_code,
             )
+
+        path_info = self.request.__dict__.get('path_info')
+        version = get_api_version_number_from_url(path_info)
+        # If it is not version 3, we don't need to check anything, just return
+        # TODO this comment seems misleading?
+        if version == Versions.V3:
+            try:
+                self.validate_v3_authorization_request()
+            except AccessDeniedError:
+                return JsonResponse(
+                    {
+                        'status_code': HTTPStatus.FORBIDDEN,
+                        'message': 'Unable to verify permission',
+                    },
+                    status=HTTPStatus.FORBIDDEN,
+                )
 
         sensitive_info_detected = self.sensitive_info_check(request)
 
@@ -325,21 +327,19 @@ class AuthorizationView(DotAuthorizationView):
         return super().get(request, *args, **kwargs)
 
     def validate_v3_authorization_request(self):
+        if self.application is None:
+            raise AccessDeniedError(description='Unable to verify permission.')
+
         flag = get_waffle_flag_model().get('v3_early_adopter')
-        req_meta = self.request.META
-        # TODO this doesn't work if method is post and the client_id is in body?
-        url_query = parse_qs(req_meta.get('QUERY_STRING'))
-        client_id = url_query.get('client_id', [None])
         try:
-            application = get_application_model().objects.get(client_id=client_id[0])
-            application_user = get_user_model().objects.get(id=application.user_id)
+            application_user = get_user_model().objects.get(id=self.application.user_id)
 
             if flag.id is None or flag.is_active_for_user(application_user):
                 # Update the class variable to ensure subsequent calls to dispatch don't call this function
                 # more times than is needed
                 return
             else:
-                raise AccessDeniedError(description=APPLICATION_DOES_NOT_HAVE_V3_ENABLED_YET.format(application.name))
+                raise AccessDeniedError(description=APPLICATION_DOES_NOT_HAVE_V3_ENABLED_YET.format(self.application.name))
         except ObjectDoesNotExist:
             raise AccessDeniedError(description='Unable to verify permission.')
 

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -169,8 +169,6 @@ class AuthorizationView(DotAuthorizationView):
 
     def __init__(self, version=1):
         self.version = version
-        # TODO should we add this so every instance at least has the attribute?
-        # self.application = None
         super().__init__()
 
     def _get_param(self, request, key, default=None):

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -326,9 +326,6 @@ class AuthorizationView(DotAuthorizationView):
         return super().get(request, *args, **kwargs)
 
     def validate_v3_authorization_request(self):
-        if self.application is None:
-            raise AccessDeniedError(description='Unable to verify permission.')
-
         flag = get_waffle_flag_model().get('v3_early_adopter')
         try:
             application_user = get_user_model().objects.get(id=self.application.user_id)

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -248,8 +248,7 @@ class AuthorizationView(DotAuthorizationView):
 
         path_info = self.request.__dict__.get('path_info')
         version = get_api_version_number_from_url(path_info)
-        # If it is not version 3, we don't need to check anything, just return
-        # TODO this comment seems misleading?
+        # If it is not version 3, we don't need to check anything, just continue
         if version == Versions.V3:
             try:
                 self.validate_v3_authorization_request()

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -327,6 +327,7 @@ class AuthorizationView(DotAuthorizationView):
     def validate_v3_authorization_request(self):
         flag = get_waffle_flag_model().get('v3_early_adopter')
         req_meta = self.request.META
+        # TODO this doesn't work if method is post and the client_id is in body?
         url_query = parse_qs(req_meta.get('QUERY_STRING'))
         client_id = url_query.get('client_id', [None])
         try:

--- a/apps/mymedicare_cb/tests/test_callback_slsx.py
+++ b/apps/mymedicare_cb/tests/test_callback_slsx.py
@@ -131,8 +131,9 @@ class MyMedicareSLSxBlueButtonClientApiUserInfoTest(BaseApiTest):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_authorize_uuid_dne(self):
+        app = self._create_application('an app')
         auth_uri = reverse('oauth2_provider:authorize-instance', args=[uuid.uuid4()])
-        response = self.client.get(auth_uri)
+        response = self.client.get(auth_uri, data={'client_id': app.client_id})
         self.assertEqual(status.HTTP_302_FOUND, response.status_code)
 
     def test_authorize_uuid(self):


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-4777](https://jira.cms.gov/browse/BB2-4777)

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
-->
Add test authorize endpoint across versions, and fix an error in `validate_v3_authorization_request` that was causing v3 post requests to fail. Also, update a signature that did not match behavior.

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->
- [x] any chance this is not a bug, but my misunderstanding?

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

1. run local stack
2. create a new application. If creating via django admin, make sure the application is assigned a user.
3. ensure v3 endpoints waffle switch is enabled
4. See that a get request succeeds:
 
```
curl -v --data 'client_id=CLIENT_ID_HERE' --data "state=$(uuidgen)" --data 'redirect_uri=http://example.doesntexist' --data 'response_type=code' --data 'code_challenge=sZrievZsrYqxdnu2NVD603EiYBM18CuzZpwB-pOSZjo' --data 'code_challenge_method=S256' --data-urlencode 'scope=patient/Patient.rs' --get http://localhost:8000/v3/o/authorize/
```

The response should be a `302 FOUND` with the URL being `/mymedicare/login` plus query parameters.

5. see that a post request fails:

(The same command, minus `--get`.)

```
curl -v --data 'client_id=CLIENT_ID_HERE' --data "state=$(uuidgen)" --data 'redirect_uri=http://example.doesntexist' --data 'response_type=code' --data 'code_challenge=sZrievZsrYqxdnu2NVD603EiYBM18CuzZpwB-pOSZjo' --data 'code_challenge_method=S256' --data-urlencode 'scope=patient/Patient.rs' http://localhost:8000/v3/o/authorize/
```

The response under this bug will be a `403 Forbidden` with the message

```
{"status_code": 403, "message": "Unable to verify permission"}
```
#### Desired Behavior

After this PR, both the GET and POST requests to `/v3/o/authorize/` should succeed with `302 FOUND` and redirect to `/mymedicare/login`.
 
A test in this PR tries all versions of the authorization endpoint with both GET and POST.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
