### PR TITLE
BB2-4811 Remove waffle switch for one hour tokens

### DIFF
--- a/apps/core/constants.py
+++ b/apps/core/constants.py
@@ -23,6 +23,5 @@ WAFFLE_FEATURE_SWITCHES = (
         True,
         'This enables the /.well-known/applications end-point. Active in prod, but not in sbx/test.',
     ),
-    ('one_hour_token_expiry', False, 'This makes OAuth2 access tokens expire in one hour.'),
     ('client_credentials_validation', True, 'Are we verifying JWT properties and signatures on client_credentials flow'),
 )

--- a/apps/dot_ext/models.py
+++ b/apps/dot_ext/models.py
@@ -25,7 +25,6 @@ from oauth2_provider.models import (
     get_application_model,
 )
 from oauth2_provider.settings import oauth2_settings
-from waffle import switch_is_active
 
 import apps.logging.request_logger as logging
 from apps.capabilities.models import ProtectedCapability
@@ -38,7 +37,6 @@ from apps.dot_ext.constants import (
 )
 
 ONE_HOUR = _('for 1 hour')
-TEN_HOURS = _('for 10 hours')
 THIRTEEN_MONTHS = _('for 13 months, until ')
 
 
@@ -218,10 +216,7 @@ class Application(AbstractApplication):
     # will recognize that the date should be localized when tagged
     def access_end_date_text(self):
         if self.has_one_time_only_data_access():
-            if switch_is_active('one_hour_token_expiry'):
-                return ONE_HOUR
-            else:
-                return TEN_HOURS
+            return ONE_HOUR
 
         # no message displayed for RESEARCH_STUDY
         else:

--- a/apps/dot_ext/oauth2_server.py
+++ b/apps/dot_ext/oauth2_server.py
@@ -24,9 +24,6 @@ def my_token_expires_in(request):
         user_id = request.client.user.pk
 
     expires_in = ExpiresIn.objects.get_expires_in(client_id, user_id)
-    # if no record is found we default to the value defined in the
-    # oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS
-    # or one hour if the one_hour_token_expiry switch is active
     if expires_in is None:
         one_hour_delta = timedelta(hours=1)
         seconds_in_one_hour = int(one_hour_delta.total_seconds())

--- a/apps/dot_ext/oauth2_server.py
+++ b/apps/dot_ext/oauth2_server.py
@@ -1,8 +1,6 @@
 from datetime import timedelta
 from urllib.parse import parse_qs
-from waffle import switch_is_active
 from oauthlib.oauth2.rfc6749.endpoints import Server as OAuthLibServer
-from oauth2_provider.settings import oauth2_settings
 
 from apps.constants import CLIENT_CREDENTIALS
 from apps.dot_ext.models import ExpiresIn
@@ -30,12 +28,9 @@ def my_token_expires_in(request):
     # oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS
     # or one hour if the one_hour_token_expiry switch is active
     if expires_in is None:
-        if switch_is_active('one_hour_token_expiry') or (grant_type[0] and grant_type[0] == CLIENT_CREDENTIALS):
-            one_hour_delta = timedelta(hours=1)
-            seconds_in_one_hour = int(one_hour_delta.total_seconds())
-            expires_in = seconds_in_one_hour
-        else:
-            expires_in = oauth2_settings.ACCESS_TOKEN_EXPIRE_SECONDS
+        one_hour_delta = timedelta(hours=1)
+        seconds_in_one_hour = int(one_hour_delta.total_seconds())
+        expires_in = seconds_in_one_hour
 
     return expires_in
 


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-4811](https://jira.cms.gov/browse/BB2-4811)

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
-->
Removes the `one_hour_token_expiry` waffle switch, treating it as True in code.

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->
- Anything missing?

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
