### PR TITLE
Noor1027/bb2 4816 release notes missing last commit

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ github.ref }}
 
       - name: Verify on master branch
         run: |
@@ -70,7 +71,7 @@ jobs:
           BODY="${NEW_TAG} - ${RELEASE_DATE}"
           BODY="${BODY}\n================"
 
-          while IFS= read -r line; do
+          while IFS= read -r line || [[ -n "$line" ]]; do
             HASH=$(echo "$line" | cut -d' ' -f1)
             SUBJECT=$(echo "$line" | cut -d' ' -f2-)
 
@@ -85,7 +86,7 @@ jobs:
                 BODY="${BODY}\n- ${SUBJECT}"
               fi
             fi
-          done < <(git log --pretty=format:'%H %s' ${PREV_TAG}..HEAD)
+          done < <(git log --pretty=tformat:'%H %s' ${PREV_TAG}..HEAD)
 
           echo -e "$BODY" > /tmp/release_notes.md
 

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Verify on master branch
         run: |
           CURRENT_BRANCH="${{ github.ref_name }}"
-          if [[ "$CURRENT_BRANCH" != "master" && "$CURRENT_BRANCH" != "Noor1027/BB2-4816-Release-notes-missing-last-commit" ]]; then
+          if [[ "$CURRENT_BRANCH" != "master" ]]; then
             echo "::error::Release must be created from master branch. Current branch: $CURRENT_BRANCH"
             exit 1
           fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Verify on master branch
         run: |
           CURRENT_BRANCH="${{ github.ref_name }}"
-          if [[ "$CURRENT_BRANCH" != "master" ]]; then
+          if [[ "$CURRENT_BRANCH" != "master" && "$CURRENT_BRANCH" != "Noor1027/BB2-4816-Release-notes-missing-last-commit" ]]; then
             echo "::error::Release must be created from master branch. Current branch: $CURRENT_BRANCH"
             exit 1
           fi


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-4816](https://jira.cms.gov/browse/BB2-4816)

### What Does This PR Do?

Fixes a bug in the publish-release workflow where the oldest commit in the release range was always silently dropped from the generated release notes.

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

The workflow from this branch against the current commit history ,all commits since the previous release tag appeared in the generated notes including the final entry that was previously dropped.

<img width="1232" height="666" alt="GHA-1" src="https://github.com/user-attachments/assets/97f1140a-5dc8-4e76-b0e3-25d63ef54549" />


### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [X ] No migrations
