### PR TITLE
Ensure patient_match_found log is queryable in Splunk/QS pipeline

### DIFF
--- a/apps/dot_ext/tests/test_authorization_token.py
+++ b/apps/dot_ext/tests/test_authorization_token.py
@@ -599,7 +599,7 @@ class TestTokenResponseFields(BaseApiTest):
                 self.assertIn('refresh_token', data)
 
                 # Ensure that specific logs are output as a result of a client_credentials call
-                assert "'patient_match_found': True" in auth_logs.output[1]
+                assert '"patient_match_found": true' in auth_logs.output[1]
                 assert '"req_grant_type": "client_credentials"' in request_logs.output[0]
                 assert '"req_app_name": "CC App"' in request_logs.output[0]
 

--- a/apps/dot_ext/views/authorization.py
+++ b/apps/dot_ext/views/authorization.py
@@ -1260,10 +1260,10 @@ class TokenView(DotTokenView):
 
                             log_dict['patient_match_found'] = True
                             log_dict['patient'] = fhir_id
-                            log.info(log_dict)
+                            log.info(json.dumps(log_dict))
                             create_or_update_data_access_grant_client_credential_flow(user, app)
                         else:
-                            log.info(log_dict)
+                            log.info(json.dumps(log_dict))
                             log.debug(f'No patient match found for client_credentials call for app: {app.name}')
                             return JsonResponse(
                                 {


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-4768](https://jira.cms.gov/browse/BB2-4768)

### What Does This PR Do?

Does a json.dumps on the patient match found log so it is queryable

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

### Validation

- Do a client_credentials call, make sure the patient_match_found log has double quotes instead of single

What it should have:
<img width="1185" height="31" alt="Screenshot 2026-07-30 at 9 01 40 AM" src="https://github.com/user-attachments/assets/0c536209-b1c1-4e8c-a229-e08de0643595" />

what it had before:
<img width="1177" height="31" alt="Screenshot 2026-07-30 at 8 59 11 AM" src="https://github.com/user-attachments/assets/bbb682f9-38e5-4ca5-971f-d8b328b0b046" />


### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
