### PR TITLE
fix calling .strip() on None

### DIFF
--- a/apps/wellknown/views/jwks.py
+++ b/apps/wellknown/views/jwks.py
@@ -17,7 +17,7 @@ def jwks_json(request):
     (``JWKS_PUBLIC_KEY_PEM`` / ``JWKS_PRIVATE_KEY_PEM``); this endpoint only needs
     the public key. Returns 404 when no public key is configured.
     """
-    public_pem = os.getenv('JWKS_PUBLIC_KEY_PEM', None).strip()
+    public_pem = os.getenv('JWKS_PUBLIC_KEY_PEM', '').strip()
     if not public_pem:
         raise Http404()
     public_pem_json = json.loads(public_pem)


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
n/a

### What Does This PR Do?

<!--
Add detailed description & discussion of changes here.
-->
Fixes code that attempts to call `.strip()` on `None`.

If the environment variable is not set, the previous code attempts to
call strip on None, and fails, returning a 500 to the user.


### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
