### PR TITLE
BB2-5041: Ensure _offset param is passed to BFD

### DIFF
--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -1051,3 +1051,36 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
             response.json()['detail'],
             APPLICATION_DOES_NOT_HAVE_VALID_SCOPES.format('John_Smith_test', 'search', 'ExplanationOfBenefit'),
         )
+
+
+@pytest.mark.integration
+@override_switch('v3_endpoints', active=True)
+def test_call_eob_v3_ensure_offset_is_passed(
+    basic_user,
+    get_access_token,
+    create_capability,
+    create_application,
+) -> None:
+    """Ensure that if a v3 search EOB call is made, and a _offset parameter is being passed,
+    that _offset is correctly passed to BFD, and is included in the link attribute of the response
+    """
+
+    eob_capability = create_capability(name=EOB_SCOPE, urls=[['GET', '/v[3]/fhir/ExplanationOfBenefit[/]?$']])
+    application = create_application(
+        name='test',
+        grant_type='authorization-code',
+        capability=eob_capability,
+    )
+
+    user = basic_user()
+    access_token = get_access_token(user.username, 'patient/ExplanationOfBenefit.rs', application=application)
+
+    url = reverse(SEARCH_EOB_URLS[Versions.V3])
+    url += '/?_offset=5'
+    response = Client().get(
+        url,
+        Authorization='Bearer %s' % (access_token),
+    )
+
+    assert response.status_code == HTTPStatus.OK
+    assert '_offset' in response.json()['link'][0]['url']

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -161,6 +161,7 @@ class SearchViewExplanationOfBenefit(SearchView):
         '_tag': list[str],
         '_source': list[str],
         '_security:not': str,
+        '_offset': Coerce(int),
     }
 
     def __init__(self, version=1):


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-5041](https://jira.cms.gov/browse/BB2-5041)

### What Does This PR Do?

Ensures the _offset parameter is passed to BFD

### What Should Reviewers Watch For?
I believe _offset is not supported by BFD for v1 or v2, so we only need to worry about v3. 

If you're reviewing this PR, please check for these things in particular:

### Validation

- Pull down the branch, run make-local auth=mock bfd=sbx
- Go through an auth flow in Postman, ensure the EOB scope is applied. Select BBUser00001
- This user has 7 EOB claims for v3 EOB calls. Run a v3 EOB search call. The 7 IDs that will be returned are: 
  - -8349728880131
  - -7640619654818
  - -5825644291472
  - -5797008597404
  - -4944438378832
  - -3526677513300
  - -3448461166848
- Run another v3 EOB search call. This time, add _offset=2 as a parameter
- _offset is now returned in the link attribute of the response. You will not see the first two IDs from the list above, the only resource IDs that will now be returned are:
  -  -5825644291472
  - -5797008597404
  - -4944438378832
  - -3526677513300
  - -3448461166848

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
