### PR TITLE
BB2-5096: Add DDPS to default source - v3 EOB Search

### DIFF
--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -659,7 +659,7 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
     @pytest.mark.integration
     @override_switch('v3_endpoints', active=True)
     def test_call_eob_v3_ensure_source_is_added(self) -> None:
-        """Ensure that if a v3 search EOB call is made, that the _source=NCH parameter
+        """Ensure that if a v3 search EOB call is made, that the _source=NCH,DDPS parameter
         is automatically added to the call, as there is no _tag or _source parameter already on the call
         """
 
@@ -684,7 +684,7 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
     @override_switch('v3_endpoints', active=True)
     def test_call_eob_v3_ensure_source_is_not_added(self) -> None:
         """Ensure that if a v3 search EOB call is made, and a _tag parameter is being passed,
-        that the _source=NCH parameter is not added to the call
+        that the _source=NCH,DDPS parameter is not added to the call
         """
 
         # create the user
@@ -1084,3 +1084,44 @@ def test_call_eob_v3_ensure_offset_is_passed(
 
     assert response.status_code == HTTPStatus.OK
     assert '_offset' in response.json()['link'][0]['url']
+
+
+@pytest.mark.integration
+@override_switch('v3_endpoints', active=True)
+def test_call_eob_v3_ensure_DDPS_source_is_added_even_with_different_tag_and_source_parameters(
+    basic_user, get_access_token, create_capability, create_application
+) -> None:
+    """Ensure that if a v3 search EOB call is made, and the access_token_extension record has
+    part_d_eob_only equal to true, that no matter what _source and _tag parameters are on the request,
+    we only pass _source=DDPS to BFD
+    """
+    user = basic_user()
+    eob_capability = create_capability(name=EOB_SCOPE, urls=[['GET', '/v[3]/fhir/ExplanationOfBenefit[/]?$']])
+    app = create_application(
+        'test app',
+        capability=eob_capability,
+        user=user,
+    )
+    ac = get_access_token(
+        user.username, 'patient/ExplanationOfBenefit.rs patient/Patient.rs patient/Coverage.rs profile', application=app
+    )
+    access_token = AccessToken.objects.get(token=ac)
+
+    access_token_extension = AccessTokenExtension()
+    access_token_extension.access_token = access_token
+    access_token_extension.part_d_eob_only = True
+    access_token_extension.save()
+
+    url = reverse(SEARCH_EOB_URLS[Versions.V3])
+    # Add params to url that will be filtered out because the token extension has part_d_eob_only = True
+    url += '/?_tag=https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|NationalClaimsHistory&_source=NCH'
+
+    response = Client().get(
+        url,
+        {},
+        HTTP_AUTHORIZATION='Bearer %s' % access_token,
+    )
+    print('JUST A LOOK: ', response.json())
+    assert response.status_code == HTTPStatus.OK
+    assert 'NCH' not in response.json()['link'][0]['url']
+    assert 'NationalClaimsHistory' not in response.json()['link'][0]['url']

--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -21,7 +21,7 @@ from apps.dot_ext.models import AccessTokenExtension, Application, ProtectedCapa
 from apps.fhir.constants import (
     BAD_PARAMS_ACCEPTABLE_VERSIONS,
     C4BB_SYSTEM_TYPES,
-    DEFAULT_EOB_SOURCE,
+    ENCODED_DEFAULT_EOB_SOURCE,
     ENFORCE_PARAM_VALIDATION,
     EXCLUDE_SAMHSA_PARAMETER_VALUE,
     FHIR_CONFORMANCE_URLS,
@@ -678,7 +678,7 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
             Authorization='Bearer %s' % (first_access_token),
         )
         self.assertEqual(response.status_code, 200)
-        assert DEFAULT_EOB_SOURCE in response.json()['link'][0]['url']
+        assert ENCODED_DEFAULT_EOB_SOURCE in response.json()['link'][0]['url']
 
     @pytest.mark.integration
     @override_switch('v3_endpoints', active=True)
@@ -703,7 +703,7 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
             Authorization='Bearer %s' % (first_access_token),
         )
         self.assertEqual(response.status_code, 200)
-        assert DEFAULT_EOB_SOURCE not in response.json()['link'][0]['url']
+        assert ENCODED_DEFAULT_EOB_SOURCE not in response.json()['link'][0]['url']
 
     @pytest.mark.integration
     @override_switch('v3_endpoints', active=True)

--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -1121,7 +1121,7 @@ def test_call_eob_v3_ensure_DDPS_source_is_added_even_with_different_tag_and_sou
         {},
         HTTP_AUTHORIZATION='Bearer %s' % access_token,
     )
-    print('JUST A LOOK: ', response.json())
+
     assert response.status_code == HTTPStatus.OK
     assert 'NCH' not in response.json()['link'][0]['url']
     assert 'NationalClaimsHistory' not in response.json()['link'][0]['url']

--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -1125,3 +1125,4 @@ def test_call_eob_v3_ensure_DDPS_source_is_added_even_with_different_tag_and_sou
     assert response.status_code == HTTPStatus.OK
     assert 'NCH' not in response.json()['link'][0]['url']
     assert 'NationalClaimsHistory' not in response.json()['link'][0]['url']
+    assert '_source=DDPS' in response.json()['link'][0]['url']

--- a/apps/fhir/bluebutton/tests/test_utils.py
+++ b/apps/fhir/bluebutton/tests/test_utils.py
@@ -638,7 +638,7 @@ class ExtractFHIRIdTestCase(BaseApiTest):
         ('_source=NCH', True, 'DDPS'),
         ('_tag=https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|NationalClaimsHistory', True, 'DDPS'),
         ('_source=NCH&_tag=https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|NationalClaimsHistory', True, 'DDPS'),
-        ('', False, 'NCH'),
+        ('', False, 'NCH,DDPS'),
         ('_source=NCH', False, None),
     ],
 )

--- a/apps/fhir/bluebutton/utils.py
+++ b/apps/fhir/bluebutton/utils.py
@@ -959,6 +959,6 @@ def determine_eob_search_parameter_to_add(query_param: str, part_d_eob_only: boo
     if part_d_eob_only:
         return 'DDPS'
     if '_tag' not in query_param and '_source' not in query_param:
-        return 'NCH'
+        return 'NCH,DDPS'
 
     return None

--- a/apps/fhir/constants.py
+++ b/apps/fhir/constants.py
@@ -139,7 +139,7 @@ USER_ID_TYPE_DEFAULT = 'H'
 
 IDI_MATCH_ENDPOINT = '$idi-match'
 
-DEFAULT_EOB_SOURCE = '_source=NCH'
+ENCODED_DEFAULT_EOB_SOURCE = '_source=NCH%2CDDPS'
 COVERAGE_READ_SCOPES = [
     'patient/Coverage.read',
     'patient/Coverage.r',


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-5096](https://jira.cms.gov/browse/BB2-5096)

### What Does This PR Do?

Adds DDPS to the default _source parameter that is passed to BFD if no _source or _tag parameter is present. If the access token extension record has part_d_eob_only equal to true, we still only pass _source=DDPS to BFD.

### What Should Reviewers Watch For?

Are the unit test modifications and additional integration test sufficient coverage?

If you're reviewing this PR, please check for these things in particular:

### Validation
- Pull down branch, run make run-local auth=mock bfd=sbx
- Run integration tests
- Go through a v3 auth flow, select BBUser00001, make sure to check the SAMHSA checkbox on the permissions screen
- Make sure that the app you are using for Postman has part_d_eob_claims_only set to false
- Run a v3 EOB Search call with no _source or _tag parameters. Add _count = 25 as a parameter
  - There should be 15 results returned. Confirm that there are EOB resources with source = DDPS or NCH. There should be no other sources. The URL in the "link" attribute should contain: _source=NCH%2CDDPS
  - Run the same call, this time with _source=NCH. You will see 7 results, with only source=NCH
- Update the oauth2_provider_accesstoken_extension record for this token. Set part_d_eob_only equal to true
  - Then run another v3 EOB Search call, should get 8 results, confirm that only _source=DDPS is present in the result/the URL in the "link" attribute.
  - Add _source=NCH and run the call again, confirm only 8 results, and that they all have source=DDPS
  - Add _tag=https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|NationalClaimsHistory, keep _source=NCH as well and run the call again. Confirm only 8 results, and all have source=DDPS

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
