### PR TITLE
BB2-4405: Contributors GHA fixes

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,6 +5,8 @@ on:
   schedule:
     # Runs on the first day of the month at 5:30AM UTC
     - cron: '30 5 1 * *'
+  push:
+    branches: [master]
 
 jobs:
   update-contributors:
@@ -19,11 +21,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create working branch
+      - name: Create branch
         run: |
-          BRANCH_NAME="update-contributors-${{ github.run_number }}"
-          git checkout -b "$BRANCH_NAME"
-          echo "Created branch $BRANCH_NAME"
+          git checkout -b "update-contributors-${{ github.run_number }}"
 
       - name: Update contributor list
         id: contrib_list

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Create working branch
+        run: |
+          BRANCH_NAME="update-contributors-${{ github.run_number }}"
+          git checkout -b "$BRANCH_NAME"
+          echo "Created branch $BRANCH_NAME"
+
       - name: Update contributor list
         id: contrib_list
         uses: akhilmhdh/contributors-readme-action@v2.3.10
@@ -28,8 +34,6 @@ jobs:
           readme_path: COMMUNITY.md
           use_username: false
           commit_message: 'update contributors information'
-          auto_detect_branch_protection: true
-          pr_title_on_protected: '[automated] Update Contributors Information'
 
       - name: Get contributors count
         id: get_contributors

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -23,7 +23,9 @@ jobs:
 
       - name: Create branch
         run: |
-          git checkout -b "update-contributors-${{ github.run_number }}"
+          BRANCH_NAME="update-contributors-${{ github.run_number }}"
+          git checkout -b "$BRANCH_NAME"
+          git push origin "$BRANCH_NAME" 
 
       - name: Update contributor list
         id: contrib_list

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -19,15 +19,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Update contributor list
-        id: contrib_list
-        uses: akhilmhdh/contributors-readme-action@v2.3.10
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          readme_path: COMMUNITY.md
-          use_username: false
-          commit_message: 'update contributors information'
+      # - name: Update contributor list
+      #   id: contrib_list
+      #   uses: akhilmhdh/contributors-readme-action@v2.3.10
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   with:
+      #     readme_path: COMMUNITY.md
+      #     use_username: false
+      #     commit_message: 'update contributors information'
 
       - name: Get contributors count
         id: get_contributors

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -6,7 +6,7 @@ on:
     # Run at 5am UTC on the first of every month
     - cron: '0 5 1 * *'
   push:
-    branches: [main]
+    branches: [jamesdemery/bb2-4405-update-contributors-action]
 
 jobs:
   update-contributors:

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -6,7 +6,7 @@ on:
     # Run at 5am UTC on the first of every month
     - cron: '0 5 1 * *'
   push:
-    branches: [jamesdemery/bb2-4405-update-contributors-action]
+    branches: [master]
 
 jobs:
   update-contributors:
@@ -15,17 +15,24 @@ jobs:
       contents: write
       pull-requests: write
 
+    env:
+      # allow a run from a feature branch
+      TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'master' }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ env.TARGET_BRANCH }}
 
       - name: Update contributor list
         id: contrib_list
         uses: akhilmhdh/contributors-readme-action@v2.3.10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REF: refs/heads/${{ env.TARGET_BRANCH }}
+          GITHUB_REF_NAME: ${{ env.TARGET_BRANCH }}
         with:
           readme_path: COMMUNITY.md
           use_username: false

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -28,7 +28,6 @@ jobs:
           readme_path: COMMUNITY.md
           use_username: false
           commit_message: 'update contributors information'
-          pr_title_on_protected: '[Automated] Update Contributors Information'
 
       - name: Get contributors count
         id: get_contributors
@@ -55,14 +54,14 @@ jobs:
 
           perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' COMMUNITY.md
 
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add COMMUNITY.md
-          git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
-
-      # - name: Push protected
-      #   uses: CasperWA/push-protected@v2
-      #   with:
-      #     token: ${{ secrets.GITHUB_TOKEN }}
-
-      #     branch: main
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "update contributors information"
+          branch: update-contributors-${{ github.run_number }}
+          title: "[automated] Update Contributors Information"
+          body: |
+            Monthly automated update of contributors information in COMMUNITY.md.
+          base: master
+          delete-branch: true

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -3,10 +3,8 @@ name: Update Contributors Information
 on:
   workflow_dispatch: {}
   schedule:
-    # Weekly on Saturdays.
-    - cron: '30 1 * * 6'
-  push:
-    branches: [main]
+    # Runs on the first day of the month at 5:30AM UTC
+    - cron: '30 5 1 * *'
 
 jobs:
   update-contributors:
@@ -30,6 +28,7 @@ jobs:
           readme_path: COMMUNITY.md
           use_username: false
           commit_message: 'update contributors information'
+          pr_title_on_protected: '[Automated] Update Contributors Information'
 
       - name: Get contributors count
         id: get_contributors
@@ -61,9 +60,9 @@ jobs:
           git add COMMUNITY.md
           git commit -m "update contributors count to $CONTRIBUTORS" || exit 0
 
-      - name: Push protected
-        uses: CasperWA/push-protected@v2
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Push protected
+      #   uses: CasperWA/push-protected@v2
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
 
-          branch: main
+      #     branch: main

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -3,10 +3,10 @@ name: Update Contributors Information
 on:
   workflow_dispatch: {}
   schedule:
-    # Runs on the first day of the month at 5:30AM UTC
-    - cron: '30 5 1 * *'
+    # Run at 5am UTC on the first of every month
+    - cron: '0 5 1 * *'
   push:
-    branches: [master]
+    branches: [main]
 
 jobs:
   update-contributors:
@@ -20,12 +20,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-
-      - name: Create branch
-        run: |
-          BRANCH_NAME="update-contributors-${{ github.run_number }}"
-          git checkout -b "$BRANCH_NAME"
-          git push origin "$BRANCH_NAME" 
 
       - name: Update contributor list
         id: contrib_list
@@ -62,14 +56,7 @@ jobs:
 
           perl -i -pe 's/(<!--CONTRIBUTOR COUNT START-->).*?(<!--CONTRIBUTOR COUNT END-->)/$1 '"$CONTRIBUTORS"' $2/' COMMUNITY.md
 
-      - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v6
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "update contributors information"
-          branch: update-contributors-${{ github.run_number }}
-          title: "[automated] Update Contributors Information"
-          body: |
-            Monthly automated update of contributors information in COMMUNITY.md.
-          base: master
-          delete-branch: true
+          git config user.name 'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add COMMUNITY.md
+          git commit -m "update contributors count to $CONTRIBUTORS" || exit 0

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -15,24 +15,17 @@ jobs:
       contents: write
       pull-requests: write
 
-    env:
-      # allow a run from a feature branch
-      TARGET_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || 'master' }}
-
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          ref: ${{ env.TARGET_BRANCH }}
 
       - name: Update contributor list
         id: contrib_list
         uses: akhilmhdh/contributors-readme-action@v2.3.10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REF: refs/heads/${{ env.TARGET_BRANCH }}
-          GITHUB_REF_NAME: ${{ env.TARGET_BRANCH }}
         with:
           readme_path: COMMUNITY.md
           use_username: false

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -18,7 +18,6 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          persist-credentials: false
 
       - name: Update contributor list
         id: contrib_list

--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -18,16 +18,19 @@ jobs:
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          persist-credentials: false
 
-      # - name: Update contributor list
-      #   id: contrib_list
-      #   uses: akhilmhdh/contributors-readme-action@v2.3.10
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   with:
-      #     readme_path: COMMUNITY.md
-      #     use_username: false
-      #     commit_message: 'update contributors information'
+      - name: Update contributor list
+        id: contrib_list
+        uses: akhilmhdh/contributors-readme-action@v2.3.10
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          readme_path: COMMUNITY.md
+          use_username: false
+          commit_message: 'update contributors information'
+          auto_detect_branch_protection: true
+          pr_title_on_protected: '[automated] Update Contributors Information'
 
       - name: Get contributors count
         id: get_contributors


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-4405](https://jira.cms.gov/browse/BB2-4405)

### What Does This PR Do?

Modifies our Update Contributors GHA to run once per month, on the first of the month at 5am UTC. It also fixes an issue where the GHA would report a failure each time, despite successfully creating a pull request.

### What Should Reviewers Watch For?

I was having a lot of difficulty testing this from the GHA UI. Whenever I would kick the action off there from my feature branch, it would fail on the Update contributor list step with a 'Branch not found' error. I'm still not 100% why this is happening, if you kick the Update Contributors GHA with any branch besides master, it will fail. I ran the action from another branch, `jamesdemery/bb2-5096-add-ddps-to-default-source`, that had no changes to contributors.yml, and the same error happened.

The GHA was reporting failure because of the Push protected step, as that was trying to push directly to master, a protected branch. The Update contributor list step has always been the one actually creating the PR, so push protected was not needed.

If you're reviewing this PR, please check for these things in particular:

### Validation

- Pull down the branch
- Run the following commands (needed to test the action locally):
  - brew install act (I chose the smallest docker image) - docs [here](https://nektosact.com/introduction.html)
  - brew install gh, there will be a series of steps to authorize - Github CLI, docs [here](https://cli.github.com/)
 
```
act workflow_dispatch \
  -W .github/workflows/contributors.yml \
  --env GITHUB_REF=refs/heads/master \
  --secret GITHUB_TOKEN=$(gh auth token) -P ubuntu-latest=catthehacker/ubuntu:act-latest
```

The command above will actually kick off the GHA. You will see a bunch of output in the terminal, and the final output should be:

[Update Contributors Information/update-contributors]   ✅  Success - Complete job
[Update Contributors Information/update-contributors] 🏁  Job succeeded

A PR should also be created, with title = docs(contributor): contributors readme action update- #1703, and a branch name like `contributors-readme-action-WhOa2j33i0`. It will have changes for COMMUNITY.md as well as the changes made to contributors.yml, but that is just because it was run from a feature branch. We can then close that PR.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
