### PR TITLE
Remove the push to master trigger from the .yml so we don't open a co…

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -5,8 +5,6 @@ on:
   schedule:
     # Run at 5am UTC on the first of every month
     - cron: '0 5 1 * *'
-  push:
-    branches: [master]
 
 jobs:
   update-contributors:


### PR DESCRIPTION
…ntributors PR on every merge

**JIRA Ticket:**
[BB2-4405](https://jira.cms.gov/browse/BB2-4405)

### What Does This PR Do?

Removes the on push to master trigger from the contributors.yml so we don't have a PR created on every merge.

### What Should Reviewers Watch For?

If you're reviewing this PR, please check for these things in particular:

### Validation

- I ran the action locally again to make sure it would still run successfully, a PR was opened as expected.
- The real validation will be after this PR is merged. If no contributors PR is opened after that, we're good. Otherwise, need to iterate again.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
