### PR TITLE
BB2-5126: Ensure _source and _tag parameters are logged

### DIFF
--- a/hhs_oauth_server/request_logging.py
+++ b/hhs_oauth_server/request_logging.py
@@ -74,6 +74,8 @@ class RequestResponseLog(object):
         - req_qparam_beneficiary = Info from HTTP Query Params. (BB2-342)
         - req_qparam_client_id = Info from HTTP Query Params. (BB2-342)
         - req_qparam__count = Info from HTTP Query Params. (BB2-342)
+        - req_qparam__source = Info from HTTP Query Params - used to track Shared Systems usage (BB2-5126)
+        - req_qparam__tag = Info from HTTP Query Params - used to track Shared Systems usage (BB2-5126)
         - req_qparam_count = Info from HTTP Query Params. (BB2-342)
         - req_qparam_format = Info from HTTP Query Params. (BB2-342)
         - req_qparam__id = Info from HTTP Query Params. (BB2-342)
@@ -303,6 +305,8 @@ class RequestResponseLog(object):
         if getattr(self.request, 'GET', False):
             # Log selected query params only
             self._log_msg_update_from_querydict('req_qparam__count', '_count')
+            self._log_msg_update_from_querydict('req_qparam__source', '_source')
+            self._log_msg_update_from_querydict('req_qparam__tag', '_tag')
             self._log_msg_update_from_querydict('req_qparam__id', '_id')
             self._log_msg_update_from_querydict('req_qparam_beneficiary', 'beneficiary')
             self._log_msg_update_from_querydict('req_qparam_beneficiary', 'Beneficiary')


### PR DESCRIPTION
**JIRA Ticket:**
[BB2-5126](https://jira.cms.gov/browse/BB2-5126)

### What Does This PR Do?

Adds logging for _source and _tag parameters. This is to enable us to track the usage of Shared Systems data.

### What Should Reviewers Watch For?

Is there a better way to log this? We need to be able to identify what values are in the _source and _tag parameters in SQL (that code is in the BFD repo). That's why I went with logging them out individually, rather than the whole query parameter string, as it will be easier to extract the values in the SQL.

Should unit tests be added? It's a small and simple change. I looked through different logging tests and didn't see much possibility without writing a large test just for this. Will continue to look for a bit.

If you're reviewing this PR, please check for these things in particular:

### Validation

- Pull down the branch, run a v3 EOB search call without _source or _tag as parameters. You will see a log something like this:

`{
bb-api-1  |   "access_token_hash": "fd11804850202617a8f4fcff5a4917a55968cc730b9393e5b65ed1e84421a9ad",
bb-api-1  |   "access_token_id": 1252,
bb-api-1  |   "access_token_scopes": "profile patient/ExplanationOfBenefit.rs patient/Coverage.rs",
bb-api-1  |   "app_id": 35,
bb-api-1  |   "app_name": "local logging",
bb-api-1  |   "app_require_demographic_scopes": true,
bb-api-1  |   "dev_id": 1,
bb-api-1  |   "dev_name": "root",
bb-api-1  |   "elapsed": 0.3357100486755371,
bb-api-1  |   "end_time": 1787769943.596946,
bb-api-1  |   "fhir_attribute_count": 7,
bb-api-1  |   "fhir_bundle_type": "searchset",
bb-api-1  |   "fhir_entry_count": 10,
bb-api-1  |   "fhir_id_v2": "-10000010254647",
bb-api-1  |   "fhir_id_v3": "-156634937",
bb-api-1  |   "fhir_resource_id": "ed5ac248-5dc4-4acb-9468-dbd52c3424b3",
bb-api-1  |   "fhir_resource_type": "Bundle",
bb-api-1  |   "ip_addr": "192.168.127.1",
bb-api-1  |   "location": "",
bb-api-1  |   "path": "/v2/fhir/ExplanationOfBenefit",
bb-api-1  |   "req_fhir_id_v2": "-10000010254647",
bb-api-1  |   "req_fhir_id_v3": "-156634937",
bb-api-1  |   "req_header_accept_encoding": "gzip, deflate, br",
bb-api-1  |   "req_header_host": "localhost:8000",
bb-api-1  |   "req_header_user_agent": "PostmanRuntime/7.56.1",
bb-api-1  |   "req_user_id": 97,
bb-api-1  |   "req_user_username": "BBUser00001",
bb-api-1  |   "request_method": "GET",
bb-api-1  |   "request_scheme": "http",
bb-api-1  |   "request_uuid": "579640fa-a17e-11f1-8a0e-aac594424301",
bb-api-1  |   "response_code": 200,
bb-api-1  |   "size": 422872,
bb-api-1  |   "start_time": 1787769943.261239,
bb-api-1  |   "type": "request_response_middleware",
bb-api-1  |   "user": "BBUser00001",
bb-api-1  |   "user_id": 97,
bb-api-1  |   "user_username": "BBUser00001"
bb-api-1  | }`

- Now, add _source=NCH and _tag=https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|NationalClaimsHistory and you will see a log like this:

`{
bb-api-1  |   "access_token_hash": "42b9b3ee5b711f912a2c6ef82b85ee3c053fc52afe4385a060a78b158111aa99",
bb-api-1  |   "access_token_id": 1253,
bb-api-1  |   "access_token_scopes": "profile patient/ExplanationOfBenefit.rs patient/Coverage.rs",
bb-api-1  |   "app_id": 35,
bb-api-1  |   "app_name": "local logging",
bb-api-1  |   "app_require_demographic_scopes": true,
bb-api-1  |   "dev_id": 1,
bb-api-1  |   "dev_name": "root",
bb-api-1  |   "elapsed": 0.40671396255493164,
bb-api-1  |   "end_time": 1787770008.352959,
bb-api-1  |   "fhir_attribute_count": 7,
bb-api-1  |   "fhir_bundle_type": "searchset",
bb-api-1  |   "fhir_entry_count": 10,
bb-api-1  |   "fhir_id_v2": "-10000010254647",
bb-api-1  |   "fhir_id_v3": "-156634937",
bb-api-1  |   "fhir_resource_id": "c7b61410-3d21-4aa7-8ef8-e0491e6aeada",
bb-api-1  |   "fhir_resource_type": "Bundle",
bb-api-1  |   "ip_addr": "192.168.127.1",
bb-api-1  |   "location": "",
bb-api-1  |   "path": "/v2/fhir/ExplanationOfBenefit",
bb-api-1  |   "req_fhir_id_v2": "-10000010254647",
bb-api-1  |   "req_fhir_id_v3": "-156634937",
bb-api-1  |   "req_header_accept_encoding": "gzip, deflate, br",
bb-api-1  |   "req_header_host": "localhost:8000",
bb-api-1  |   "req_header_user_agent": "PostmanRuntime/7.56.1",
bb-api-1  |   "req_qparam__source": "NCH",
bb-api-1  |   "req_qparam__tag": "https://bluebutton.cms.gov/fhir/CodeSystem/System-Type|NationalClaimsHistory",
bb-api-1  |   "req_user_id": 97,
bb-api-1  |   "req_user_username": "BBUser00001",
bb-api-1  |   "request_method": "GET",
bb-api-1  |   "request_scheme": "http",
bb-api-1  |   "request_uuid": "7e245b6c-a17e-11f1-9423-aac594424301",
bb-api-1  |   "response_code": 200,
bb-api-1  |   "size": 423304,
bb-api-1  |   "start_time": 1787770007.946247,
bb-api-1  |   "type": "request_response_middleware",
bb-api-1  |   "user": "BBUser00001",
bb-api-1  |   "user_id": 97,
bb-api-1  |   "user_username": "BBUser00001"
bb-api-1  | }`

- Confirm that you see req_qparam__source and req_qparam__tag in the log. Also run v3 EOB search calls with only one of those parameters included, and make sure it shows up in the log.

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
