### PR TITLE
removing some validation of query params to allow BFD to handle params

### DIFF
--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -574,60 +574,6 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
 
     @pytest.mark.integration
     @override_switch('v3_endpoints', active=True)
-    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
-    def test_eob_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
-        """An unrecognized search parameter is passed through to BFD rather than rejected here,
-        for every version, regardless of the Prefer header."""
-        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
-
-        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
-        response = client.get(
-            reverse(SEARCH_EOB_URLS[version]),
-            {'hello': 'world'},
-            Authorization=f'Bearer {access_token}',
-            **extra_headers,
-        )
-
-        assert response.status_code == HTTPStatus.OK
-
-    @pytest.mark.integration
-    @override_switch('v3_endpoints', active=True)
-    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
-    def test_coverage_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
-        """An unrecognized search parameter is passed through to BFD rather than rejected here,
-        for every version, regardless of the Prefer header."""
-        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
-
-        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
-        response = client.get(
-            reverse(SEARCH_COVERAGE_URLS[version]),
-            {'hello': 'world'},
-            Authorization=f'Bearer {access_token}',
-            **extra_headers,
-        )
-
-        assert response.status_code == HTTPStatus.OK
-
-    @pytest.mark.integration
-    @override_switch('v3_endpoints', active=True)
-    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
-    def test_patient_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
-        """An unrecognized search parameter is passed through to BFD rather than rejected here,
-        for every version, regardless of the Prefer header."""
-        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
-
-        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
-        response = client.get(
-            reverse(SEARCH_PATIENT_URLS[version]),
-            {'hello': 'world'},
-            Authorization=f'Bearer {access_token}',
-            **extra_headers,
-        )
-
-        assert response.status_code == HTTPStatus.OK
-
-    @pytest.mark.integration
-    @override_switch('v3_endpoints', active=True)
     def test_call_eob_v3_ensure_source_is_added(self) -> None:
         """Ensure that if a v3 search EOB call is made, that the _source=NCH,DDPS parameter
         is automatically added to the call, as there is no _tag or _source parameter already on the call
@@ -1096,3 +1042,57 @@ def test_call_eob_v3_ensure_DDPS_source_is_added_even_with_different_tag_and_sou
     assert 'NCH' not in response.json()['link'][0]['url']
     assert 'NationalClaimsHistory' not in response.json()['link'][0]['url']
     assert '_source=DDPS' in response.json()['link'][0]['url']
+
+    @pytest.mark.integration
+    @override_switch('v3_endpoints', active=True)
+    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
+    def test_eob_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
+        """An unrecognized search parameter is passed through to BFD rather than rejected here,
+        for every version, regardless of the Prefer header."""
+        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
+
+        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
+        response = client.get(
+            reverse(SEARCH_EOB_URLS[version]),
+            {'hello': 'world'},
+            Authorization=f'Bearer {access_token}',
+            **extra_headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.integration
+    @override_switch('v3_endpoints', active=True)
+    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
+    def test_coverage_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
+        """An unrecognized search parameter is passed through to BFD rather than rejected here,
+        for every version, regardless of the Prefer header."""
+        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
+
+        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
+        response = client.get(
+            reverse(SEARCH_COVERAGE_URLS[version]),
+            {'hello': 'world'},
+            Authorization=f'Bearer {access_token}',
+            **extra_headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.integration
+    @override_switch('v3_endpoints', active=True)
+    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
+    def test_patient_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
+        """An unrecognized search parameter is passed through to BFD rather than rejected here,
+        for every version, regardless of the Prefer header."""
+        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
+
+        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
+        response = client.get(
+            reverse(SEARCH_PATIENT_URLS[version]),
+            {'hello': 'world'},
+            Authorization=f'Bearer {access_token}',
+            **extra_headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK

--- a/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
+++ b/apps/fhir/bluebutton/tests/test_fhir_resources_read_search_w_validation.py
@@ -19,10 +19,9 @@ from apps.constants import (
 )
 from apps.dot_ext.models import AccessTokenExtension, Application, ProtectedCapability
 from apps.fhir.constants import (
-    BAD_PARAMS_ACCEPTABLE_VERSIONS,
+    BASE_PARAM_SCOPE,
     C4BB_SYSTEM_TYPES,
     ENCODED_DEFAULT_EOB_SOURCE,
-    ENFORCE_PARAM_VALIDATION,
     EXCLUDE_SAMHSA_PARAMETER_VALUE,
     FHIR_CONFORMANCE_URLS,
     READ_UPDATE_DELETE_COVERAGE_URLS,
@@ -574,87 +573,58 @@ class FHIRResourcesReadSearchTest(BaseApiTest):
             self.assertEqual(response.status_code, expected_code)
 
     @pytest.mark.integration
-    def test_eob_request_when_thrown_when_invalid_parameters_included_v1_and_v2(self) -> None:
-        for version in BAD_PARAMS_ACCEPTABLE_VERSIONS:
-            url = SEARCH_EOB_URLS[version]
-            self._test_request_when_invalid_parameters_included(url, version, HTTPStatus.OK, ENFORCE_PARAM_VALIDATION)
-
-    @pytest.mark.integration
-    def test_coverage_request_when_thrown_when_invalid_parameters_included_v1_and_v2(self) -> None:
-        for version in BAD_PARAMS_ACCEPTABLE_VERSIONS:
-            url = SEARCH_COVERAGE_URLS[version]
-            self._test_request_when_invalid_parameters_included(url, version, HTTPStatus.OK, ENFORCE_PARAM_VALIDATION)
-
-    @pytest.mark.integration
-    def test_patient_request_when_thrown_when_invalid_parameters_included_v1_and_v2(self) -> None:
-        for version in BAD_PARAMS_ACCEPTABLE_VERSIONS:
-            url = SEARCH_PATIENT_URLS[version]
-            self._test_request_when_invalid_parameters_included(url, version, HTTPStatus.OK, ENFORCE_PARAM_VALIDATION)
-
-    @pytest.mark.integration
-    def test_eob_request_when_thrown_when_invalid_parameters_and_prefer_strict_header_included_v3(self) -> None:
-        url = SEARCH_EOB_URLS[Versions.V3]
-        self._test_request_when_invalid_parameters_included(
-            url, Versions.V3, HTTPStatus.BAD_REQUEST, ENFORCE_PARAM_VALIDATION
-        )
-
-    @pytest.mark.integration
-    def test_coverage_request_when_thrown_when_invalid_parameters_and_prefer_strict_header_included_v3(self) -> None:
-        url = SEARCH_COVERAGE_URLS[Versions.V3]
-        self._test_request_when_invalid_parameters_included(
-            url, Versions.V3, HTTPStatus.BAD_REQUEST, ENFORCE_PARAM_VALIDATION
-        )
-
-    @pytest.mark.integration
-    def test_patient_request_when_invalid_parameters_and_prefer_strict_header_included_v3(self) -> None:
-        url = SEARCH_PATIENT_URLS[Versions.V3]
-        self._test_request_when_invalid_parameters_included(
-            url, Versions.V3, HTTPStatus.BAD_REQUEST, ENFORCE_PARAM_VALIDATION
-        )
-
-    @pytest.mark.integration
-    def test_eob_request_when_thrown_when_invalid_parameters_and_prefer_lenient_header_included_v3(self) -> None:
-        url = SEARCH_EOB_URLS[Versions.V3]
-        self._test_request_when_invalid_parameters_included(url, Versions.V3, HTTPStatus.OK, 'handling=lenient')
-
-    @pytest.mark.integration
-    def test_coverage_request_when_thrown_when_invalid_parameters_and_prefer_lenient_header_included_v3(self) -> None:
-        url = SEARCH_COVERAGE_URLS[Versions.V3]
-        self._test_request_when_invalid_parameters_included(url, Versions.V3, HTTPStatus.OK, 'handling=lenient')
-
-    @pytest.mark.integration
-    def test_patient_request_when_invalid_parameters_and_prefer_lenient_header_included_v3(self) -> None:
-        url = SEARCH_PATIENT_URLS[Versions.V3]
-        self._test_request_when_invalid_parameters_included(url, Versions.V3, HTTPStatus.OK, 'handling=lenient')
-
     @override_switch('v3_endpoints', active=True)
-    def _test_request_when_invalid_parameters_included(
-        self, url: str, version: int, expected_response_code: HTTPStatus, prefer_header: str
-    ) -> None:
-        """Ensure that a 400 is thrown for each type of resource call when invalid parameters are included for v3
-        And that it is a 200 response when it is v1 or v2
+    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
+    def test_eob_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
+        """An unrecognized search parameter is passed through to BFD rather than rejected here,
+        for every version, regardless of the Prefer header."""
+        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
 
-        Args:
-            url (str): The url that will be called in the test
-            expected_bad_params (List[str]): The bad parameters that cause the 400 error to be thrown
-        """
-        # create the user
-        first_access_token = self.create_token(
-            'John', 'Smith', fhir_id_v2=DEFAULT_SAMPLE_FHIR_ID_V2, fhir_id_v3=DEFAULT_SAMPLE_FHIR_ID_V3
-        )
-        ac = AccessToken.objects.get(token=first_access_token)
-        ac.scope = 'patient/Coverage.search patient/Patient.search patient/ExplanationOfBenefit.search'
-        ac.save()
-
-        response = self.client.get(
-            reverse(url),
+        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
+        response = client.get(
+            reverse(SEARCH_EOB_URLS[version]),
             {'hello': 'world'},
-            Authorization='Bearer %s' % (first_access_token),
-            HTTP_PREFER=prefer_header,
+            Authorization=f'Bearer {access_token}',
+            **extra_headers,
         )
-        self.assertEqual(response.status_code, expected_response_code)
-        if version == Versions.V3 and prefer_header == ENFORCE_PARAM_VALIDATION:
-            self.assertEqual(response.json()['error'], "Invalid parameters: ['hello']")
+
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.integration
+    @override_switch('v3_endpoints', active=True)
+    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
+    def test_coverage_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
+        """An unrecognized search parameter is passed through to BFD rather than rejected here,
+        for every version, regardless of the Prefer header."""
+        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
+
+        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
+        response = client.get(
+            reverse(SEARCH_COVERAGE_URLS[version]),
+            {'hello': 'world'},
+            Authorization=f'Bearer {access_token}',
+            **extra_headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
+
+    @pytest.mark.integration
+    @override_switch('v3_endpoints', active=True)
+    @pytest.mark.parametrize('prefer_header', [None, 'handling=strict', 'handling=lenient'])
+    def test_patient_search_with_unrecognized_parameter_succeeds(client, version, bene_access_token, prefer_header):
+        """An unrecognized search parameter is passed through to BFD rather than rejected here,
+        for every version, regardless of the Prefer header."""
+        access_token = bene_access_token(scope=BASE_PARAM_SCOPE)
+
+        extra_headers = {'HTTP_PREFER': prefer_header} if prefer_header else {}
+        response = client.get(
+            reverse(SEARCH_PATIENT_URLS[version]),
+            {'hello': 'world'},
+            Authorization=f'Bearer {access_token}',
+            **extra_headers,
+        )
+
+        assert response.status_code == HTTPStatus.OK
 
     @pytest.mark.integration
     @override_switch('v3_endpoints', active=True)

--- a/apps/fhir/bluebutton/views/generic.py
+++ b/apps/fhir/bluebutton/views/generic.py
@@ -7,7 +7,7 @@ from django.core.exceptions import ObjectDoesNotExist
 from oauth2_provider.models import AccessToken
 from requests import Request, Session
 from rest_framework import exceptions, permissions
-from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.exceptions import NotFound
 from rest_framework.parsers import JSONParser
 from rest_framework.renderers import JSONRenderer
 from rest_framework.response import Response
@@ -30,9 +30,8 @@ from apps.fhir.bluebutton.utils import (
     build_fhir_response,
     determine_eob_search_parameter_to_add,
     valid_patient_read_or_search_call,
-    validate_query_parameters,
 )
-from apps.fhir.constants import ENFORCE_PARAM_VALIDATION, EXCLUDE_SAMHSA_PARAMETER_VALUE
+from apps.fhir.constants import EXCLUDE_SAMHSA_PARAMETER_VALUE
 from apps.fhir.parsers import FHIRParser
 from apps.fhir.renderers import FHIRRenderer
 from apps.fhir.server import connection as backend_connection
@@ -155,16 +154,6 @@ class FhirDataView(APIView):
 
         prepped = s.prepare_request(req)
         query_param = prepped.headers.get('BlueButton-OriginalQuery')
-        accepted_query_parameters = getattr(self, 'QUERY_SCHEMA', {})
-        request_prefer_header = request.META.get('HTTP_PREFER')
-
-        if request_prefer_header == ENFORCE_PARAM_VALIDATION and query_param and self.version == Versions.V3:
-            accepted_query_parameters = getattr(self, 'QUERY_SCHEMA', {})
-            validation_result = validate_query_parameters(accepted_query_parameters, query_param)
-            if not validation_result.valid:
-                # We are raising a ValidationError here so that, even when DEBUG = False, a developer
-                # making the request can see what the invalid parameters were so they can fix the request
-                raise ValidationError({'error': f'Invalid parameters: {validation_result.invalid_params}'})
 
         # If a v3 EOB call is being made, and include_samhsa for the access token associated with the request is False
         # make sure to add a parameter that will filter out SAMHSA data

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -1,7 +1,7 @@
 import waffle
 from rest_framework import permissions
 from voluptuous import (
-    ALLOW_EXTRA,
+    REMOVE_EXTRA,
     All,
     Coerce,
     Match,
@@ -192,6 +192,6 @@ class SearchViewExplanationOfBenefit(SearchView):
             params['_tag'] = request.query_params.getlist('_tag')
             params['_source'] = request.query_params.getlist('_source')
 
-        schema = Schema(query_schema, extra=ALLOW_EXTRA)
+        schema = Schema(query_schema, extra=REMOVE_EXTRA)
 
         return schema(params)

--- a/apps/fhir/bluebutton/views/search.py
+++ b/apps/fhir/bluebutton/views/search.py
@@ -1,7 +1,7 @@
 import waffle
 from rest_framework import permissions
 from voluptuous import (
-    REMOVE_EXTRA,
+    ALLOW_EXTRA,
     All,
     Coerce,
     Match,
@@ -192,6 +192,6 @@ class SearchViewExplanationOfBenefit(SearchView):
             params['_tag'] = request.query_params.getlist('_tag')
             params['_source'] = request.query_params.getlist('_source')
 
-        schema = Schema(query_schema, extra=REMOVE_EXTRA)
+        schema = Schema(query_schema, extra=ALLOW_EXTRA)
 
         return schema(params)

--- a/apps/fhir/constants.py
+++ b/apps/fhir/constants.py
@@ -185,3 +185,5 @@ READ_SEARCH_SCOPE_LOOKUP = {
     },
 }
 EXCLUDE_SAMHSA_PARAMETER_VALUE = '42CFRPart2'
+
+BASE_PARAM_SCOPE = 'patient/Coverage.search patient/Patient.search patient/ExplanationOfBenefit.search'


### PR DESCRIPTION


**JIRA Ticket:**
[BB2-5053](https://jira.cms.gov/browse/BB2-5053)

### What Does This PR Do?

Removes some validation around invalid query parameters for v3 calls so that we no longer need to stay in lockstep with BFD around query parameters. This however, does open up BFD to other unexpected parameters.

(https://confluence.cms.gov/spaces/BB2/pages/1685381184/Investigation+of+strict+lenient+handling+of+parameters)
### What Should Reviewers Watch For?

Any possible test cases or variations of Prefer:handling = strict or Prefer:handling = lenient that seem wrong.

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [X] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [ ] No migrations
