### PR TITLE
BB2-5123:Support custom migration command override in Fargate deployment workflow

### DIFF
--- a/.github/workflows/deploy-api-fargate.yml
+++ b/.github/workflows/deploy-api-fargate.yml
@@ -25,7 +25,7 @@ on:
           - pre-deploy
           - post-deploy
       migrate_command:
-        description: "Run just part of a release's migrations, for whichever step you picked above. Example: 'migrate --noinput dot_ext 0016_some_migration'."
+        description: "Override custom migrate command (e.g. 'migrate --noinput dot_ext 0016_some_migration')."
         required: false
         type: string
         default: ''

--- a/.github/workflows/deploy-api-fargate.yml
+++ b/.github/workflows/deploy-api-fargate.yml
@@ -25,7 +25,7 @@ on:
           - pre-deploy
           - post-deploy
       migrate_command:
-        description: "Leave blank to run the usual 'migrate --noinput'. Fill it in when a release needs its migrations split around the deploy, e.g. 'migrate --noinput dot_ext 0016_some_migration'. Does nothing if migration_type is none."
+        description: "Run just part of a release's migrations, for whichever step you picked above. Example: 'migrate --noinput dot_ext 0016_some_migration'."
         required: false
         type: string
         default: ''
@@ -153,7 +153,7 @@ jobs:
     environment: ${{ inputs.environment || 'test' }}
     steps:
       - name: Confirm approval
-        run: echo "${{ github.actor }} approved this — about to run '${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}' against the new image, before it goes live."
+        run: echo "${{ github.actor }} approved the pre-deploy migration — running '${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}' against the new image, before any traffic hits it."
 
   pre-migrate:
     name: Pre-deploy ${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }} on ${{ inputs.environment || 'test' }}
@@ -256,7 +256,7 @@ jobs:
     environment: ${{ inputs.environment || 'test' }}
     steps:
       - name: Confirm approval
-        run: echo "${{ github.actor }} approved this — about to run '${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}' against the live service."
+        run: echo "${{ github.actor }} approved the post-deploy migration — running '${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}' against the live service, new code already serving."
 
   post-migrate:
     name: Post-deploy ${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }} on ${{ inputs.environment || 'test' }}

--- a/.github/workflows/deploy-api-fargate.yml
+++ b/.github/workflows/deploy-api-fargate.yml
@@ -25,7 +25,7 @@ on:
           - pre-deploy
           - post-deploy
       migrate_command:
-        description: "Override custom migrate command (e.g. 'migrate --noinput dot_ext 0016_some_migration')."
+        description: "(Optional) Override custom migrate command (e.g. 'migrate --noinput dot_ext 0016_some_migration')."
         required: false
         type: string
         default: ''

--- a/.github/workflows/deploy-api-fargate.yml
+++ b/.github/workflows/deploy-api-fargate.yml
@@ -24,6 +24,11 @@ on:
           - none
           - pre-deploy
           - post-deploy
+      migrate_command:
+        description: "Leave blank to run the usual 'migrate --noinput'. Fill it in when a release needs its migrations split around the deploy, e.g. 'migrate --noinput dot_ext 0016_some_migration'. Does nothing if migration_type is none."
+        required: false
+        type: string
+        default: ''
 
 env:
   AWS_REGION: us-east-1
@@ -126,6 +131,7 @@ jobs:
   # Run migrations before the service update.
   # First, we check for pending migrations. Then, we wait for a team member to approve the deployment.
   # Finally, we run the migrations. If any of these steps fail, the deployment stops to prevent issues.
+  # migrate_command narrows this down when a release can't run all its migrations at once.
 
   pre-showmigrations:
     name: Pre-deploy showmigrations on ${{ inputs.environment || 'test' }}
@@ -147,16 +153,16 @@ jobs:
     environment: ${{ inputs.environment || 'test' }}
     steps:
       - name: Confirm approval
-        run: echo "Approved by ${{ github.actor }} — running migrate --noinput against the new image."
+        run: echo "${{ github.actor }} approved this — about to run '${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}' against the new image, before it goes live."
 
   pre-migrate:
-    name: Pre-deploy migrate --noinput on ${{ inputs.environment || 'test' }}
+    name: Pre-deploy ${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }} on ${{ inputs.environment || 'test' }}
     needs: [prepare, approve-pre-migration]
     if: inputs.migration_type == 'pre-deploy'
     uses: ./.github/workflows/run-manage-command.yml
     with:
       environment: ${{ inputs.environment || 'test' }}
-      command: migrate --noinput
+      command: ${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}
       task_definition_arn: ${{ needs.prepare.outputs.task_definition_arn }}
     secrets: inherit
 
@@ -229,6 +235,7 @@ jobs:
   # Run migrations after the service update.
   # The new code is already running, so we run migrations on the live database.
   # We still check for pending migrations, wait for approval, and then run them.
+  # A failure here hits after the deploy is already live, so it can't block anything.
 
   post-showmigrations:
     name: Post-deploy showmigrations on ${{ inputs.environment || 'test' }}
@@ -249,14 +256,14 @@ jobs:
     environment: ${{ inputs.environment || 'test' }}
     steps:
       - name: Confirm approval
-        run: echo "Approved by ${{ github.actor }} — running migrate --noinput against the live service."
+        run: echo "${{ github.actor }} approved this — about to run '${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}' against the live service."
 
   post-migrate:
-    name: Post-deploy migrate --noinput on ${{ inputs.environment || 'test' }}
+    name: Post-deploy ${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }} on ${{ inputs.environment || 'test' }}
     needs: approve-post-migration
     if: inputs.migration_type == 'post-deploy'
     uses: ./.github/workflows/run-manage-command.yml
     with:
       environment: ${{ inputs.environment || 'test' }}
-      command: migrate --noinput
+      command: ${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}
     secrets: inherit


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-5123](https://jira.cms.gov/browse/BB2-5123)

### What Does This PR Do?

This PR adds an custom `migrate_command` input to the `Deploy to Fargate` workflow (`deploy-api-fargate.yml`). 
<img width="726" height="1120" alt="image" src="https://github.com/user-attachments/assets/d2ab9be7-8c5b-4de9-9dee-c3e68cd5cf0f" />


### What Should Reviewers Watch For?

* **Fallback logic:** Verify `${{ inputs.migrate_command != '' && inputs.migrate_command || 'migrate --noinput' }}` correctly falls back to `migrate --noinput` when the field is empty or unset.
* **Approval visibility:** Verify that the approval steps (`approve-pre-migration` and `approve-post-migration`) print the resolved command so approvers know what they are authorizing.
* **Scope:** Confirm that `migration_type: none` remains unaffected and still skips all migration jobs.

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation

<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [ X] No migrations
