### PR TITLE
Switch Account Selenium Test

### DIFF
--- a/apps/integration_tests/constants.py
+++ b/apps/integration_tests/constants.py
@@ -1011,6 +1011,7 @@ EXPECTED_LOGGING_EVENTS = [
 HOSTNAME_URL = os.getenv('HOSTNAME_URL', 'http://localhost:8000')
 USE_NEW_PERM_SCREEN = os.getenv('USE_NEW_PERM_SCREEN')
 USE_LOGIN_WITH_MEDICARE_BUTTON = os.getenv('USE_LOGIN_WITH_MEDICARE_BUTTON', 'false')
+USE_MSLSX = os.getenv('USE_MSLSX', 'false')
 PROD_URL = 'https://api.bluebutton.cms.gov'
 SANDBOX_URL = 'https://sandbox.bluebutton.cms.gov'
 USER_ACTIVATION_PATH_FMT = '{}/v1/accounts/activation-verify/{}'
@@ -1038,15 +1039,13 @@ TESTCASE_BANNER_FMT = '** {} TEST: {}, API: {}, STEP: {}, {}'
 UI Widget text: texts on e.g. buttons, links, labels etc.
 """
 
-# Synthetic beneficiary login info
-BENE_TXT_USERNAME = 'BBUser09003'
-BENE_TXT_PASSWORD_TEST = 'PW09003!'
-BENE_TXT_PASSWORD_PROD = 'PW09003!'
-BENE_TXT_PASSWORD = (
-    BENE_TXT_PASSWORD_PROD
-    if HOSTNAME_URL.startswith(PROD_URL) or HOSTNAME_URL.startswith(SANDBOX_URL)
-    else BENE_TXT_PASSWORD_TEST
-)
+# SLSX BBUser09003 Synthetic beneficiary login info
+BENE_TXT_BBUSER_09003_USERNAME = 'BBUser09003'
+BENE_TXT_BBUSER_09003_PASSWORD = 'PW09003!'
+
+# SLSX BBUser00000 Synthetic beneficiary login info
+BENE_TXT_BBUSER_00000_USERNAME = 'BBUser00000'
+BENE_TXT_BBUSER_00000_PASSWORD = 'PW00000!'
 
 LNK_TXT_SIGNUP = 'Signup'
 TAG_FOR_AUTHORIZE_LINK = 'pre'
@@ -1076,10 +1075,18 @@ FHIR_RESULT_BTN_COPY = 'bb-copy-button'
 MSLSX_TXT_FLD_USERNAME = 'username'
 MSLSX_TXT_FLD_HICN = 'hicn'
 MSLSX_TXT_FLD_MBI = 'mbi'
-MSLSX_TXT_FLD_USERNAME_VAL = '0854b54d-5d3c-4d73-ab45-aa6f052ed31a'  # synthetic ID, cleared with SLS
-MSLSX_TXT_FLD_HICN_VAL = '00000000000'
-MSLSX_TXT_FLD_MBI_VAL = '1S00EU8DG39'
 MSLSX_BTN_SUBMIT = 'button'
+
+# Synthetic ID, cleared with SLS. Used for all users using MSLSX login.
+MSLSX_TXT_FLD_USERNAME_VAL = '0854b54d-5d3c-4d73-ab45-aa6f052ed31a'
+
+# MSLSX hicn and mbi values for BBUser09003
+MSLSX_TXT_FLD_BBUSER_09003_HICN_VAL = '00000000000'
+MSLSX_TXT_FLD_BBUSER_09003_MBI_VAL = '1S00EU8DG39'
+
+# MSLSX hicn and mbi values for BBUser00000
+MSLSX_TXT_FLD_BBUSER_00000_HICN_VAL = '1000079035'
+MSLSX_TXT_FLD_BBUSER_00000_MBI_VAL = '1S00EU7JH19'
 
 # MSLSX login Fred
 MSLSX_TXT_FLD_FRED_USERNAME_VAL = 'rogersf'
@@ -1166,8 +1173,6 @@ APP_CSS_SELECTOR_DELETE_APP = '.cta-button:nth-child(2)'
 # SLSX login form
 SLSX_TXT_FLD_USERNAME = 'username'
 SLSX_TXT_FLD_PASSWORD = 'password'
-SLSX_TXT_FLD_USERNAME_VAL = BENE_TXT_USERNAME
-SLSX_TXT_FLD_PASSWORD_VAL = BENE_TXT_PASSWORD
 SLSX_CSS_BUTTON = 'login-button'
 SLSX_CSS_CONTINUE_BUTTON = "button[type='submit']"
 SLSX_CSS_LOGIN_BUTTON = (
@@ -1305,94 +1310,36 @@ CLICK_ENGLISH = {
     'params': [20, By.LINK_TEXT, LNK_TXT_ENGLISH],
 }
 
-CALL_LOGIN = {
-    'display': 'Start login ...',
+# Login sequence for synthetic beneficiary BBUser09003, used in both MSLSX and SLSX login
+CALL_LOGIN_BBUSER_09003 = {
+    'display': 'Start login for BBUser09003...',
     'action': Action.LOGIN,
+    'params': [
+        MSLSX_TXT_FLD_USERNAME_VAL,
+        MSLSX_TXT_FLD_BBUSER_09003_HICN_VAL,
+        MSLSX_TXT_FLD_BBUSER_09003_MBI_VAL,
+    ]
+    if USE_MSLSX == 'true'
+    else [BENE_TXT_BBUSER_09003_USERNAME, BENE_TXT_BBUSER_09003_PASSWORD],
+}
+
+# Login sequence for synthetic beneficiary BBUser00000, used in both MSLSX and SLSX login
+CALL_LOGIN_BBUSER_00000 = {
+    'display': 'Start login for BBUser00000...',
+    'action': Action.LOGIN,
+    'params': [
+        MSLSX_TXT_FLD_USERNAME_VAL,
+        MSLSX_TXT_FLD_BBUSER_00000_HICN_VAL,
+        MSLSX_TXT_FLD_BBUSER_00000_MBI_VAL,
+    ]
+    if USE_MSLSX == 'true'
+    else [BENE_TXT_BBUSER_00000_USERNAME, BENE_TXT_BBUSER_00000_PASSWORD],
 }
 
 # Navigate back to TestClient home page, different between prod and test/sbx/local
 TESTCLIENT_HOME = [
     WAIT_SECONDS,
     CLICK_TESTCLIENT_LINK if not HOSTNAME_URL.startswith(PROD_URL) else LOAD_TESTCLIENT_HOME,
-    WAIT_SECONDS,
-]
-
-# MSLSX login using BBUser09003
-SEQ_LOGIN_MSLSX = [
-    {
-        'display': 'Input SUB(username)',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, MSLSX_TXT_FLD_USERNAME, MSLSX_TXT_FLD_USERNAME_VAL],
-    },
-    {
-        'display': 'Input hicn',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, MSLSX_TXT_FLD_HICN, MSLSX_TXT_FLD_HICN_VAL],
-    },
-    {
-        'display': 'Input mbi',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, MSLSX_TXT_FLD_MBI, MSLSX_TXT_FLD_MBI_VAL],
-    },
-    {
-        'display': "Click 'submit' on MSLSX login form",
-        'action': Action.FIND_CLICK,
-        'params': [20, By.CSS_SELECTOR, MSLSX_BTN_SUBMIT],
-    },
-]
-
-# MSLSX login, but using the Fred super user (currently unused)
-SEQ_LOGIN_MSLSX_FRED = [
-    {
-        'display': 'Input SUB(username)',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, MSLSX_TXT_FLD_USERNAME, MSLSX_TXT_FLD_FRED_USERNAME_VAL],
-    },
-    {
-        'display': 'Input hicn',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, MSLSX_TXT_FLD_HICN, MSLSX_TXT_FLD_FRED_HICN_VAL],
-    },
-    {
-        'display': 'Input mbi',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, MSLSX_TXT_FLD_MBI, MSLSX_TXT_FLD_FRED_MBI_VAL],
-    },
-    {
-        'display': "Click 'submit' on MSLSX login form",
-        'action': Action.FIND_CLICK,
-        'params': [20, By.CSS_SELECTOR, MSLSX_BTN_SUBMIT],
-    },
-]
-
-# SLSX login using BBUser09003
-SEQ_LOGIN_SLSX = [
-    {
-        'display': 'Click on Medicare.gov option - continue authorization',
-        'action': Action.FIND_CLICK,
-        'params': [15, By.XPATH, X_PATH_FOR_MEDICARE_LOGIN],
-    },
-    {
-        'display': 'Medicare.gov login username',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, SLSX_TXT_FLD_USERNAME, SLSX_TXT_FLD_USERNAME_VAL],
-    },
-    {
-        'display': "Click 'Continue' on SLSX login form",
-        'action': Action.FIND_CLICK,
-        'params': [20, By.CSS_SELECTOR, SLSX_CSS_CONTINUE_BUTTON],
-    },
-    WAIT_SECONDS,
-    {
-        'display': 'Medicare.gov login password',
-        'action': Action.FIND_SEND_KEY,
-        'params': [20, By.NAME, SLSX_TXT_FLD_PASSWORD, SLSX_TXT_FLD_PASSWORD_VAL],
-    },
-    {
-        'display': "Click 'Log In' on SLSX login form",
-        'action': Action.FIND_CLICK,
-        'params': [20, By.XPATH, SLSX_CSS_LOGIN_BUTTON],
-    },
     WAIT_SECONDS,
 ]
 
@@ -1769,39 +1716,39 @@ SEQ_CHECK_SCOPES = [
 TESTS = {
     'auth_grant_fhir_calls_v2': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_AGREE_ACCESS,
         {'sequence': SEQ_QUERY_FHIR_RESOURCES_V2},
     ],
     'auth_grant_fhir_calls_v3': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V3},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_AGREE_ACCESS,
         {'sequence': SEQ_QUERY_FHIR_RESOURCES_V3},
     ],
     'auth_deny_fhir_calls_v2': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_DENY_ACCESS,
         CHECK_TESTCLIENT_START_PAGE,
     ],
     'auth_grant_w_no_demo_v2': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_RADIO_NOT_SHARE,
         CLICK_AGREE_ACCESS,
         {'sequence': SEQ_QUERY_FHIR_RESOURCES_NO_DEMO},
     ],
     'auth_grant_w_no_demo_new_perm_screen': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_RADIO_NOT_SHARE_NEW_PERM_SCREEN,
         CLICK_AGREE_ACCESS,
         {'sequence': SEQ_QUERY_FHIR_RESOURCES_NO_DEMO},
     ],
     'authorize_lang_english_button': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         WAIT_SECONDS,
         WAIT_SECONDS,
         # check the title
@@ -1827,7 +1774,7 @@ TESTS = {
     ],
     'authorize_get_v2_scopes': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         WAIT_SECONDS,
         WAIT_SECONDS,
         CLICK_AGREE_ACCESS,
@@ -1836,7 +1783,7 @@ TESTS = {
     ],
     'samhsa_box_checked_eob_response_v3': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V3},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_SAMHSA_CHECKBOX,
         CLICK_AGREE_ACCESS,
         # Check to ensure we DON'T filter out SAMHSA data by ensuring
@@ -1845,7 +1792,7 @@ TESTS = {
     ],
     'samhsa_box_not_checked_eob_response_v3': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V3},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_AGREE_ACCESS,
         # Check to ensure we DO filter out SAMHSA data by ensuring
         # _security%3Anot=42CFRPart2 IS part of the EOB url response.
@@ -1855,10 +1802,10 @@ TESTS = {
     'switch_account_v3': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V3},
         # Login as one user
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_SWITCH_ACCOUNT,
         # Login as a different user
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_00000,
         CLICK_AGREE_ACCESS,
         # Check to ensure we reached the test client home page by making an EOB Call
         CLICK_EOB_LINK,
@@ -1870,7 +1817,7 @@ SPANISH_TESTS = {
     'toggle_language': [
         # kick off default test client
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         # Wait to make sure we're logged in because login page also has Spanish link
         WAIT_SECONDS,
         WAIT_SECONDS,
@@ -1906,9 +1853,9 @@ SPANISH_TESTS = {
             'action': Action.CONTAIN_TEXT,
             'params': [20, By.ID, SLSX_CSS_BUTTON, SLSX_LOGIN_BUTTON_SPANISH],
         },
-        # note, for now CALL_LOGIN does not use locale based text to look up elements
+        # note, for now CALL_LOGIN_BBUSER_09003 does not use locale based text to look up elements
         # so it is lang agnostic
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         WAIT_SECONDS,
         WAIT_SECONDS,
         # check the title
@@ -1935,9 +1882,9 @@ SPANISH_TESTS = {
     ],
     'authorize_lang_spanish_button': [
         {'sequence': SEQ_AUTHORIZE_START_SPANISH},
-        # note, CALL_LOGIN does not use locale based text to look up elements
+        # note, CALL_LOGIN_BBUSER_09003 does not use locale based text to look up elements
         # so it is lang agnostic
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         WAIT_SECONDS,
         WAIT_SECONDS,
         # check the title
@@ -2238,11 +2185,11 @@ ACCT_TESTS = {
     # call authorize twice (1st call and 2nd call) - only 1st call emit email notification
     'first_api_call_email': [
         {'sequence': SEQ_AUTHORIZE_PKCE_START_V1_V2},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_AGREE_ACCESS,
         VALIDATE_1ST_APP_CREATED_EMAIL,
         {'sequence': SEQ_AUTHORIZE_RESTART},
-        CALL_LOGIN,
+        CALL_LOGIN_BBUSER_09003,
         CLICK_AGREE_ACCESS,
         VALIDATE_1ST_APP_CREATED_EMAIL,
     ],

--- a/apps/integration_tests/constants.py
+++ b/apps/integration_tests/constants.py
@@ -1202,6 +1202,9 @@ X_PATH_FOR_MEDICARE_LOGIN = '//*[@id="App"]/div/div[5]/button/div/div[2]/h2'
 # Samhsa checkbox on v3 permissions screen
 X_PATH_FOR_SAMHSA_CHECKBOX = '//*[@type="checkbox"]'
 
+# Switch account x path for v3
+X_PATH_FOR_SWITCH_ACCOUNT = "//button[contains(text(), 'Switch account')]"
+
 # SAMHSA filter in url response
 SAMHSA_FILTER = '_security%3Anot=42CFRPart2'
 
@@ -1276,6 +1279,12 @@ CLICK_SAMHSA_CHECKBOX = {
     'display': "Click 'SAMHSA' checkbox to agree to share SAMHSA data",
     'action': Action.FIND_CLICK,
     'params': [20, By.XPATH, X_PATH_FOR_SAMHSA_CHECKBOX],
+}
+
+CLICK_SWITCH_ACCOUNT = {
+    'display': "Click 'Switch Account' on permissions screen",
+    'action': Action.FIND_CLICK,
+    'params': [20, By.XPATH, X_PATH_FOR_SWITCH_ACCOUNT],
 }
 
 CLICK_DENY_ACCESS = {
@@ -1842,6 +1851,18 @@ TESTS = {
         # _security%3Anot=42CFRPart2 IS part of the EOB url response.
         # The checkbox is not selected by default, so we don't need to click it to uncheck it.
         {'sequence': SEQ_QUERY_EOB_SAMHSA_NOT_SHARING},
+    ],
+    'switch_account_v3': [
+        {'sequence': SEQ_AUTHORIZE_PKCE_START_V3},
+        # Login as one user
+        CALL_LOGIN,
+        CLICK_SWITCH_ACCOUNT,
+        # Login as a different user
+        CALL_LOGIN,
+        CLICK_AGREE_ACCESS,
+        # Check to ensure we reached the test client home page by making an EOB Call
+        CLICK_EOB_LINK,
+        {'sequence': TESTCLIENT_HOME},
     ],
 }
 

--- a/apps/integration_tests/selenium_generic.py
+++ b/apps/integration_tests/selenium_generic.py
@@ -73,7 +73,7 @@ class SeleniumGenericTests:
         self.environment = os.getenv('TARGET_ENV', '')
         self.on_remote_ci = os.getenv('ON_REMOTE_CI', 'false')
         self.selenium_grid_host = os.getenv('SELENIUM_GRID_HOST', 'chrome')
-        self.selenium_grid = os.getenv('SELENIUM_GRID', 'false')
+        self.selenium_grid = os.getenv('SELENIUM_GRID', 'true')
         self.hostname_url = os.environ['HOSTNAME_URL']
         self.use_mslsx = os.environ['USE_MSLSX']
         self.login_seq = SEQ_LOGIN_MSLSX if self.use_mslsx == 'true' else SEQ_LOGIN_SLSX

--- a/apps/integration_tests/selenium_generic.py
+++ b/apps/integration_tests/selenium_generic.py
@@ -8,7 +8,7 @@ from selenium import webdriver
 from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.chrome.service import Service
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
+from selenium.webdriver.remote.webelement import WebElement
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.wait import WebDriverWait
 
@@ -20,11 +20,18 @@ from apps.integration_tests.common_utils import (
 )
 from apps.integration_tests.constants import (
     ES_ES,
+    MSLSX_BTN_SUBMIT,
+    MSLSX_TXT_FLD_HICN,
+    MSLSX_TXT_FLD_MBI,
+    MSLSX_TXT_FLD_USERNAME,
     PROD_URL,
-    SEQ_LOGIN_MSLSX,
-    SEQ_LOGIN_SLSX,
+    SLSX_CSS_CONTINUE_BUTTON,
+    SLSX_CSS_LOGIN_BUTTON,
+    SLSX_TXT_FLD_PASSWORD,
+    SLSX_TXT_FLD_USERNAME,
     TESTCASE_BANNER_FMT,
     TESTCLIENT_LNK_TXT_RESTART,
+    WAIT_SECONDS,
     X_PATH_FOR_MEDICARE_LOGIN,
     Action,
 )
@@ -76,7 +83,6 @@ class SeleniumGenericTests:
         self.selenium_grid = os.getenv('SELENIUM_GRID', 'true')
         self.hostname_url = os.environ['HOSTNAME_URL']
         self.use_mslsx = os.environ['USE_MSLSX']
-        self.login_seq = SEQ_LOGIN_MSLSX if self.use_mslsx == 'true' else SEQ_LOGIN_SLSX
         msg_fmt = 'use_mslsx={}, hostname_url={}, selenium_grid={}'
         msg = msg_fmt.format(self.use_mslsx, self.hostname_url, self.selenium_grid)
         print(msg)
@@ -128,7 +134,18 @@ class SeleniumGenericTests:
     def teardown_method(self, method):
         self.driver.quit()
 
-    def _validate_email_content(self, subj_line, key_line_prefix, **kwargs):
+    def _validate_email_content(self, subj_line: str, key_line_prefix: str, **kwargs) -> str:
+        """
+        Validate that an email with the specified subject line and key line prefix has been sent.
+
+        Args:
+            subj_line (str): The subject line to look for in the email log.
+            key_line_prefix (str): The prefix of the key line to look for in the email log.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            str: The extracted activation key, if found.
+        """
         with open(LOG_FILE, 'r') as f:
             log_records = f.readlines()
             email_subj_cnt = 0
@@ -155,7 +172,22 @@ class SeleniumGenericTests:
                 assert ak is not None
             return ak
 
-    def _find_and_click(self, timeout_sec, by, by_expr, **kwargs):
+    def _find_and_click(self, timeout_sec: int, by: By, by_expr: str, **kwargs) -> WebElement:
+        """
+        Find an element on the page and click it.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            WebElement: The found element.
+        Raises:
+            TimeoutException: If the element is not found within the specified timeout.
+            Exception: For any other unexpected errors during the element search.
+        """
         log_step(f"Looking for element to CLICK: {by}='{by_expr}' (timeout: {timeout_sec}s)", 'INFO')
 
         try:
@@ -184,10 +216,36 @@ class SeleniumGenericTests:
             check_element_state(self.driver, by, by_expr, 'exception')
             raise
 
-    def _testclient_home(self, **kwargs):
+    def _testclient_home(self, **kwargs) -> WebElement:
+        """
+        Click on the "Restart" link on the test client home page to reset the state for the next test.
+
+        Args:
+            **kwargs: Arbitrary keyword arguments. These are not used in this function
+                but are included for consistency with other action methods.
+
+        Returns:
+            WebElement: The found "Restart" link element.
+        """
         return self._find_and_click(30, By.LINK_TEXT, TESTCLIENT_LNK_TXT_RESTART, **kwargs)
 
-    def _find_and_sendkey(self, timeout_sec, by, by_expr, txt, **kwargs):
+    def _find_and_sendkey(self, timeout_sec: int, by: By, by_expr: str, txt: str, **kwargs) -> WebElement:
+        """
+        Find an element on the page and send keys to it.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            txt (str): The text to send to the element.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            WebElement: The found element.
+        Raises:
+            TimeoutException: If the element is not found within the specified timeout.
+            Exception: For any other unexpected errors during the element search.
+        """
         log_step(f"Looking for element to SEND KEYS: {by}='{by_expr}' (timeout: {timeout_sec}s)", 'INFO')
         print(f"    Keys to send: '{txt}'")
 
@@ -215,7 +273,22 @@ class SeleniumGenericTests:
             check_element_state(self.driver, by, by_expr, 'exception')
             raise
 
-    def _find_and_return(self, timeout_sec, by, by_expr, **kwargs):
+    def _find_and_return(self, timeout_sec: int, by: By, by_expr: str, **kwargs) -> WebElement:
+        """
+        Find an element on the page and return it.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            WebElement: The found element.
+        Raises:
+            TimeoutException: If the element is not found within the specified timeout.
+            Exception: For any other unexpected errors during the element search.
+        """
         log_step(f"Looking for element: {by}='{by_expr}' (timeout: {timeout_sec}s)", 'INFO')
 
         try:
@@ -232,7 +305,16 @@ class SeleniumGenericTests:
             check_element_state(self.driver, by, by_expr, 'exception')
             raise
 
-    def _load_page(self, url, **kwargs):
+    def _load_page(self, url: str, **kwargs) -> None:
+        """
+        Load a web page using the Selenium web driver.
+
+        Args:
+            url (str): The URL of the page to load.
+            **kwargs: Arbitrary keyword arguments.
+        Returns:
+            None. The function loads the page and logs the action.
+        """
         if url == PROD_URL or url == PROD_URL + '/':
             print('Skip loading page: {}'.format(url))
         else:
@@ -240,7 +322,22 @@ class SeleniumGenericTests:
             self.driver.get(url)
             log_step(f'Page loaded: {self.driver.title}', 'SUCCESS')
 
-    def _check_page_title(self, timeout_sec, by, by_expr, fmt, resource_type, **kwargs):
+    def _check_page_title(self, timeout_sec: int, by: By, by_expr: str, fmt: str, resource_type: str, **kwargs) -> None:
+        """
+        Check that the page title matches the expected format.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            fmt (str): The format string for the expected page title.
+            resource_type (str): The type of the resource.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            None. The function performs the validation and raises an AssertionError if the page title
+            does not match the expected format.
+        """
         elem = self._find_and_return(timeout_sec, by, by_expr, **kwargs)
         expected = fmt.format(resource_type, kwargs.get('api_ver'))
         if not (elem.text == expected):
@@ -249,21 +346,69 @@ class SeleniumGenericTests:
             print(f"\tGot: '{elem.text}'")
         assert elem.text == expected
 
-    def _check_pkce_challenge(self, timeout_sec, by, by_expr, pkce, **kwargs):
+    def _check_pkce_challenge(self, timeout_sec: int, by: By, by_expr: str, pkce: bool, **kwargs) -> None:
+        """
+        Check if the PKCE challenge is present or absent in the page content.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            pkce (bool): Whether the PKCE challenge should be present.
+            **kwargs: Arbitrary keyword arguments.
+
+        Returns:
+            None. The function performs the validation and raises an AssertionError if the PKCE challenge
+            is not found when it should be or if the PKCE challenge is found when it should not be.
+        """
         elem = self._find_and_return(timeout_sec, by, by_expr, **kwargs)
         if pkce:
             assert 'code_challenge' in elem.text and 'code_challenge_method' in elem.text
         else:
             assert not ('code_challenge' in elem.text or 'code_challenge_method' in elem.text)
 
-    def _check_page_content(self, timeout_sec, by, by_expr, content_txt, should_exist=True, **kwargs):
+    def _check_page_content(
+        self, timeout_sec: int, by: By, by_expr: str, content_txt: str, should_exist: bool = True, **kwargs
+    ) -> None:
+        """
+        Check if the specified content text is present or absent in the page content.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            content_txt (str): The text to search for in the page content.
+            should_exist (bool): Whether the text should exist in the page content.
+            **kwargs: Arbitrary keyword arguments. These are not used in this function
+                but are included for consistency with other action methods.
+
+        Returns:
+            None. The function performs the validation and raises an AssertionError if the text
+            is not found when it should be or if the text is found when it should not be.
+        """
         elem = self._find_and_return(timeout_sec, by, by_expr, **kwargs)
         if should_exist:
             assert content_txt in elem.text
         else:
             assert content_txt not in elem.text
 
-    def _check_date_format(self, timeout_sec, by, by_expr, format, lang, **kwargs):
+    def _check_date_format(self, timeout_sec: int, by: By, by_expr: str, format: str, lang: str, **kwargs) -> None:
+        """
+        Check that the date format of the element matches the expected format.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            format (str): The expected date format as a regular expression.
+            lang (str): The language code (e.g., 'en' for English, 'es' for Spanish) to determine the month format.
+            **kwargs: Arbitrary keyword arguments. These are not used in this function
+                but are included for consistency with other action methods.
+
+        Returns:
+            None. The function performs the validation and raises an AssertionError if the date format
+            does not match the expected format or if the date is not within the expected range.
+        """
         elem = self._find_and_return(timeout_sec, by, by_expr, **kwargs)
         pattern = re.compile(format)
         m = pattern.match(elem.text)
@@ -299,30 +444,89 @@ class SeleniumGenericTests:
             print(e)
             assert 1 < 0, f"Malformed date value '{elem.text}'"
 
-    def _copy_link_and_load_with_param(self, timeout_sec, by, by_expr, **kwargs):
+    def _copy_link_and_load_with_param(self, timeout_sec: int, by: By, by_expr: str, **kwargs) -> None:
+        """
+        Copy the href from an element and load it with an additional parameter.
+
+        Args:
+            timeout_sec (int): The maximum time to wait for the element to be visible.
+            by (By): The method to locate the element (e.g., By.ID, By.NAME, By.XPATH).
+            by_expr (str): The expression to locate the element (e.g., the ID, name, or XPath).
+            **kwargs: Arbitrary keyword arguments. These are not used in this function but
+                are included for consistency with other action methods.
+        Returns:
+            None. The function performs the action and does not return any value.
+        """
         elem = WebDriverWait(self.driver, timeout_sec).until(EC.visibility_of_element_located((by, by_expr)))
         assert elem is not None
         url = f'{elem.get_attribute("href")}&lang=es'
         log_step(f'Copying link and adding param: {url}', 'INFO')
         self.driver.get(url)
 
-    def _back(self, **kwargs):
+    def _back(self, **kwargs) -> None:
+        """
+        Navigate back to the previous page in the browser history.
+
+        Args:
+            **kwargs: Arbitrary keyword arguments. These are not used in this function
+                but are included for consistency with other action methods.
+
+        Returns:
+            None. The function performs the navigation and does not return any value.
+        """
         log_step('Navigating back', 'INFO')
         self.driver.back()
 
-    def _sleep(self, sec, **kwargs):
+    def _sleep(self, sec: int, **kwargs) -> None:
+        """
+        Sleep for a specified number of seconds.
+
+        Args:
+            sec (int): The number of seconds to sleep.
+            **kwargs: Arbitrary keyword arguments. These are not used in this function
+                but are included for consistency with other action methods.
+
+        Returns:
+            None. The function performs the sleep operation and does not return any value.
+        """
         log_step(f'Sleeping for {sec} seconds', 'INFO')
         time.sleep(sec)
 
-    def _login(self, step, **kwargs):
+    def _login(self, *params, step, **kwargs):
+        """
+        Login sequence for a synthetic beneficiary, used in both MSLSX and SLSX login.
+
+        Args:
+            *params: Variable length argument list. The parameters are expected to be in the order of
+                username, hicn, mbi for MSLSX and username, password for SLSX.
+            step: A list containing the current step number. This is used to keep
+                track of the step number across recursive calls.
+            **kwargs: Arbitrary keyword arguments. These are passed to the underlying _play method.
+
+        Returns:
+            None. The function performs the login sequence and does not return any value.
+        """
         log_step('Starting login sequence', 'INFO')
-        if self.use_mslsx == 'false':
-            # dismiss Medicare.gov popup if present
-            webdriver.ActionChains(self.driver).send_keys(Keys.ESCAPE).perform()
-        self._play(self.login_seq, step, **kwargs)
+        if self.use_mslsx == 'true':
+            self._play(self._get_login_mslsx_sequence(*params), step, **kwargs)
+        else:
+            self._play(self._get_login_slsx_sequence(*params), step, **kwargs)
         log_step('Login sequence completed', 'SUCCESS')
 
     def _print_testcase_banner(self, test_name, api_ver, step_0, id_service, start=True):
+        """
+        Print a banner indicating the start or end of a test case.
+
+        Args:
+            test_name (str): The name of the test case.
+            api_ver (str): The API version being tested.
+            step_0 (int): The current step number.
+            id_service (str): The identity service being used ('true' for Mock SLS, 'false' for SLSX).
+            start (bool): True if the banner is for the start of the test case, False if it is for the end.
+
+        Returns:
+            None. The function prints the banner and does not return any value.
+        """
         print('\n******************************************************************')
         print(
             TESTCASE_BANNER_FMT.format(
@@ -332,7 +536,18 @@ class SeleniumGenericTests:
         print(f'** Timestamp: {datetime.now().strftime("%Y-%m-%d %H:%M:%S")}')
         print('******************************************************************\n')
 
-    def _play(self, lst, step, **kwargs):
+    def _play(self, lst: list, step: list, **kwargs) -> None:
+        """
+        Play a sequence of actions defined in a list of dictionaries.
+        Each dictionary should contain an 'action' key.
+
+        Args:
+            lst (list): A list of dictionaries, each representing an action to perform.
+            step (list): A list containing the current step number. This is used to keep track of the step number across recursive calls.
+            **kwargs: Arbitrary keyword arguments. These are passed to the underlying action methods.
+        Returns:
+            None. The function performs the actions and does not return any value.
+        """
         for s in lst:
             seq = s.get('sequence')
             # expects sequence of actions or action
@@ -349,7 +564,7 @@ class SeleniumGenericTests:
                     print(f'{step[0]}:{display_msg}')
                     try:
                         if action == Action.LOGIN:
-                            self.actions[action](*s.get('params', []), step, **kwargs)
+                            self.actions[action](*s.get('params', []), step=step, **kwargs)
                         else:
                             self.actions[action](*s.get('params', []), **kwargs)
                     except TimeoutException as timeout:
@@ -366,3 +581,77 @@ class SeleniumGenericTests:
                         raise
                 else:
                     raise ValueError('Invalid test case, expect dict with action...')
+
+    def _get_login_mslsx_sequence(self, username: str, hicn: str, mbi: str) -> list[dict[str, any]]:
+        """
+        Generates a dynamic login sequence with configurable credentials.
+
+        Args:
+            username (str): The username to use for login.
+            hicn (str): The HICN to use for login.
+            mbi (str): The MBI to use for login.
+        Returns:
+            list: A list of dictionaries representing the login sequence.
+        """
+        return [
+            {
+                'display': 'Input SUB(username)',
+                'action': Action.FIND_SEND_KEY,
+                'params': [20, By.NAME, MSLSX_TXT_FLD_USERNAME, username],
+            },
+            {
+                'display': 'Input hicn',
+                'action': Action.FIND_SEND_KEY,
+                'params': [20, By.NAME, MSLSX_TXT_FLD_HICN, hicn],
+            },
+            {
+                'display': 'Input mbi',
+                'action': Action.FIND_SEND_KEY,
+                'params': [20, By.NAME, MSLSX_TXT_FLD_MBI, mbi],
+            },
+            {
+                'display': "Click 'submit' on MSLSX login form",
+                'action': Action.FIND_CLICK,
+                'params': [20, By.CSS_SELECTOR, MSLSX_BTN_SUBMIT],
+            },
+        ]
+
+    def _get_login_slsx_sequence(self, username: str, password: str) -> list[dict[str, any]]:
+        """
+        Generates a dynamic login sequence with configurable credentials for SLSX.
+
+        Args:
+            username (str): The username to use for login.
+            password (str): The password to use for login.
+        Returns:
+            list: A list of dictionaries representing the login sequence.
+        """
+        return [
+            {
+                'display': 'Click on Medicare.gov option - continue authorization',
+                'action': Action.FIND_CLICK,
+                'params': [15, By.XPATH, X_PATH_FOR_MEDICARE_LOGIN],
+            },
+            {
+                'display': 'Medicare.gov login username',
+                'action': Action.FIND_SEND_KEY,
+                'params': [20, By.NAME, SLSX_TXT_FLD_USERNAME, username],
+            },
+            {
+                'display': "Click 'Continue' on SLSX login form",
+                'action': Action.FIND_CLICK,
+                'params': [20, By.CSS_SELECTOR, SLSX_CSS_CONTINUE_BUTTON],
+            },
+            WAIT_SECONDS,
+            {
+                'display': 'Medicare.gov login password',
+                'action': Action.FIND_SEND_KEY,
+                'params': [20, By.NAME, SLSX_TXT_FLD_PASSWORD, password],
+            },
+            {
+                'display': "Click 'Log In' on SLSX login form",
+                'action': Action.FIND_CLICK,
+                'params': [20, By.XPATH, SLSX_CSS_LOGIN_BUTTON],
+            },
+            WAIT_SECONDS,
+        ]

--- a/apps/integration_tests/selenium_generic.py
+++ b/apps/integration_tests/selenium_generic.py
@@ -80,7 +80,7 @@ class SeleniumGenericTests:
         self.environment = os.getenv('TARGET_ENV', '')
         self.on_remote_ci = os.getenv('ON_REMOTE_CI', 'false')
         self.selenium_grid_host = os.getenv('SELENIUM_GRID_HOST', 'chrome')
-        self.selenium_grid = os.getenv('SELENIUM_GRID', 'true')
+        self.selenium_grid = os.getenv('SELENIUM_GRID', 'false')
         self.hostname_url = os.environ['HOSTNAME_URL']
         self.use_mslsx = os.environ['USE_MSLSX']
         msg_fmt = 'use_mslsx={}, hostname_url={}, selenium_grid={}'

--- a/apps/integration_tests/selenium_generic.py
+++ b/apps/integration_tests/selenium_generic.py
@@ -582,7 +582,7 @@ class SeleniumGenericTests:
                 else:
                     raise ValueError('Invalid test case, expect dict with action...')
 
-    def _get_login_mslsx_sequence(self, username: str, hicn: str, mbi: str) -> list[dict[str, any]]:
+    def _get_login_mslsx_sequence(self, username: str, hicn: str, mbi: str, **kwargs) -> list[dict[str, any]]:
         """
         Generates a dynamic login sequence with configurable credentials.
 
@@ -590,6 +590,7 @@ class SeleniumGenericTests:
             username (str): The username to use for login.
             hicn (str): The HICN to use for login.
             mbi (str): The MBI to use for login.
+            **kwargs: Arbitrary keyword arguments.
         Returns:
             list: A list of dictionaries representing the login sequence.
         """
@@ -616,13 +617,14 @@ class SeleniumGenericTests:
             },
         ]
 
-    def _get_login_slsx_sequence(self, username: str, password: str) -> list[dict[str, any]]:
+    def _get_login_slsx_sequence(self, username: str, password: str, **kwargs) -> list[dict[str, any]]:
         """
         Generates a dynamic login sequence with configurable credentials for SLSX.
 
         Args:
             username (str): The username to use for login.
             password (str): The password to use for login.
+            **kwargs: Arbitrary keyword arguments.
         Returns:
             list: A list of dictionaries representing the login sequence.
         """

--- a/apps/integration_tests/selenium_generic.py
+++ b/apps/integration_tests/selenium_generic.py
@@ -582,7 +582,7 @@ class SeleniumGenericTests:
                 else:
                     raise ValueError('Invalid test case, expect dict with action...')
 
-    def _get_login_mslsx_sequence(self, username: str, hicn: str, mbi: str, **kwargs) -> list[dict[str, any]]:
+    def _get_login_mslsx_sequence(self, username: str, hicn: str, mbi: str) -> list[dict[str, any]]:
         """
         Generates a dynamic login sequence with configurable credentials.
 
@@ -590,7 +590,6 @@ class SeleniumGenericTests:
             username (str): The username to use for login.
             hicn (str): The HICN to use for login.
             mbi (str): The MBI to use for login.
-            **kwargs: Arbitrary keyword arguments.
         Returns:
             list: A list of dictionaries representing the login sequence.
         """
@@ -617,14 +616,13 @@ class SeleniumGenericTests:
             },
         ]
 
-    def _get_login_slsx_sequence(self, username: str, password: str, **kwargs) -> list[dict[str, any]]:
+    def _get_login_slsx_sequence(self, username: str, password: str) -> list[dict[str, any]]:
         """
         Generates a dynamic login sequence with configurable credentials for SLSX.
 
         Args:
             username (str): The username to use for login.
             password (str): The password to use for login.
-            **kwargs: Arbitrary keyword arguments.
         Returns:
             list: A list of dictionaries representing the login sequence.
         """

--- a/apps/integration_tests/selenium_spanish_tests.py
+++ b/apps/integration_tests/selenium_spanish_tests.py
@@ -1,73 +1,73 @@
-from apps.integration_tests.common_utils import screenshot_on_exception
-from apps.integration_tests.constants import SPANISH_TESTS
-from apps.versions import Versions
+# from apps.integration_tests.common_utils import screenshot_on_exception
+# from apps.integration_tests.constants import SPANISH_TESTS
+# from apps.versions import Versions
 
-from .selenium_generic import SeleniumGenericTests
+# from .selenium_generic import SeleniumGenericTests
 
-USE_NEW_PERM_SCREEN = 'true'
+# USE_NEW_PERM_SCREEN = 'true'
 
-"""
-For running against an actual SlSx server (i.e. TEST, SBX),
-not for the mock SLSx implementation
-"""
+# """
+# For running against an actual SlSx server (i.e. TEST, SBX),
+# not for the mock SLSx implementation
+# """
 
 
-class TestPermissionScreenSpanish(SeleniumGenericTests):
-    """
-    Test Spanish permission screen flow through the built in testclient by
-    leveraging selenium web driver (chrome is used)
-    """
+# class TestPermissionScreenSpanish(SeleniumGenericTests):
+#     """
+#     Test Spanish permission screen flow through the built in testclient by
+#     leveraging selenium web driver (chrome is used)
+#     """
 
-    @screenshot_on_exception
-    def test_toggle_language_and_date_format(self):
-        """
-        Test lang and date format via the built in
-        testclient using the Selenium web driver (Chrome)
-        """
-        step = [0]
-        test_name = 'toggle_language'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        if not self.use_mslsx:
-            self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
-            self._testclient_home()
-        else:
-            assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+#     @screenshot_on_exception
+#     def test_toggle_language_and_date_format(self):
+#         """
+#         Test lang and date format via the built in
+#         testclient using the Selenium web driver (Chrome)
+#         """
+#         step = [0]
+#         test_name = 'toggle_language'
+#         api_ver = Versions.V2
+#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+#         if not self.use_mslsx:
+#             self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
+#             self._testclient_home()
+#         else:
+#             assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
+#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    @screenshot_on_exception
-    def test_authorize_lang_param(self):
-        """
-        Test lang param support on the authorize end point via the built in
-        testclient using the Selenium web driver (Chrome)
-        inject lang=es before direct to login url
-        """
-        step = [0]
-        test_name = 'authorize_lang_param'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        if not self.use_mslsx:
-            self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
-            self._testclient_home()
-        else:
-            assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+#     @screenshot_on_exception
+#     def test_authorize_lang_param(self):
+#         """
+#         Test lang param support on the authorize end point via the built in
+#         testclient using the Selenium web driver (Chrome)
+#         inject lang=es before direct to login url
+#         """
+#         step = [0]
+#         test_name = 'authorize_lang_param'
+#         api_ver = Versions.V2
+#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+#         if not self.use_mslsx:
+#             self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
+#             self._testclient_home()
+#         else:
+#             assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
+#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    @screenshot_on_exception
-    def test_authorize_lang_spanish_button(self):
-        """
-        Test lang param support on the authorize end point via the built in
-        testclient using the Selenium web driver (Chrome)
-        direct to login url with lang=es by click on "Authorize as beneficiary (Spanish)" button
-        """
-        step = [0]
-        test_name = 'authorize_lang_spanish_button'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        if USE_NEW_PERM_SCREEN == 'true':
-            # the validation of expire date etc. only applicable to new perm screen
-            self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
-        else:
-            print('Skip test ' + test_name + ' - only for new perm screen.')
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+#     @screenshot_on_exception
+#     def test_authorize_lang_spanish_button(self):
+#         """
+#         Test lang param support on the authorize end point via the built in
+#         testclient using the Selenium web driver (Chrome)
+#         direct to login url with lang=es by click on "Authorize as beneficiary (Spanish)" button
+#         """
+#         step = [0]
+#         test_name = 'authorize_lang_spanish_button'
+#         api_ver = Versions.V2
+#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+#         if USE_NEW_PERM_SCREEN == 'true':
+#             # the validation of expire date etc. only applicable to new perm screen
+#             self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
+#         else:
+#             print('Skip test ' + test_name + ' - only for new perm screen.')
+#         self._testclient_home()
+#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)

--- a/apps/integration_tests/selenium_spanish_tests.py
+++ b/apps/integration_tests/selenium_spanish_tests.py
@@ -1,73 +1,73 @@
-# from apps.integration_tests.common_utils import screenshot_on_exception
-# from apps.integration_tests.constants import SPANISH_TESTS
-# from apps.versions import Versions
+from apps.integration_tests.common_utils import screenshot_on_exception
+from apps.integration_tests.constants import SPANISH_TESTS
+from apps.versions import Versions
 
-# from .selenium_generic import SeleniumGenericTests
+from .selenium_generic import SeleniumGenericTests
 
-# USE_NEW_PERM_SCREEN = 'true'
+USE_NEW_PERM_SCREEN = 'true'
 
-# """
-# For running against an actual SlSx server (i.e. TEST, SBX),
-# not for the mock SLSx implementation
-# """
+"""
+For running against an actual SlSx server (i.e. TEST, SBX),
+not for the mock SLSx implementation
+"""
 
 
-# class TestPermissionScreenSpanish(SeleniumGenericTests):
-#     """
-#     Test Spanish permission screen flow through the built in testclient by
-#     leveraging selenium web driver (chrome is used)
-#     """
+class TestPermissionScreenSpanish(SeleniumGenericTests):
+    """
+    Test Spanish permission screen flow through the built in testclient by
+    leveraging selenium web driver (chrome is used)
+    """
 
-#     @screenshot_on_exception
-#     def test_toggle_language_and_date_format(self):
-#         """
-#         Test lang and date format via the built in
-#         testclient using the Selenium web driver (Chrome)
-#         """
-#         step = [0]
-#         test_name = 'toggle_language'
-#         api_ver = Versions.V2
-#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-#         if not self.use_mslsx:
-#             self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
-#             self._testclient_home()
-#         else:
-#             assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
-#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_toggle_language_and_date_format(self):
+        """
+        Test lang and date format via the built in
+        testclient using the Selenium web driver (Chrome)
+        """
+        step = [0]
+        test_name = 'toggle_language'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        if not self.use_mslsx:
+            self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
+            self._testclient_home()
+        else:
+            assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-#     @screenshot_on_exception
-#     def test_authorize_lang_param(self):
-#         """
-#         Test lang param support on the authorize end point via the built in
-#         testclient using the Selenium web driver (Chrome)
-#         inject lang=es before direct to login url
-#         """
-#         step = [0]
-#         test_name = 'authorize_lang_param'
-#         api_ver = Versions.V2
-#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-#         if not self.use_mslsx:
-#             self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
-#             self._testclient_home()
-#         else:
-#             assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
-#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_authorize_lang_param(self):
+        """
+        Test lang param support on the authorize end point via the built in
+        testclient using the Selenium web driver (Chrome)
+        inject lang=es before direct to login url
+        """
+        step = [0]
+        test_name = 'authorize_lang_param'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        if not self.use_mslsx:
+            self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
+            self._testclient_home()
+        else:
+            assert True, 'Skip test ' + test_name + ' - does not applicable to mslsx (mock login).'
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-#     @screenshot_on_exception
-#     def test_authorize_lang_spanish_button(self):
-#         """
-#         Test lang param support on the authorize end point via the built in
-#         testclient using the Selenium web driver (Chrome)
-#         direct to login url with lang=es by click on "Authorize as beneficiary (Spanish)" button
-#         """
-#         step = [0]
-#         test_name = 'authorize_lang_spanish_button'
-#         api_ver = Versions.V2
-#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-#         if USE_NEW_PERM_SCREEN == 'true':
-#             # the validation of expire date etc. only applicable to new perm screen
-#             self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
-#         else:
-#             print('Skip test ' + test_name + ' - only for new perm screen.')
-#         self._testclient_home()
-#         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_authorize_lang_spanish_button(self):
+        """
+        Test lang param support on the authorize end point via the built in
+        testclient using the Selenium web driver (Chrome)
+        direct to login url with lang=es by click on "Authorize as beneficiary (Spanish)" button
+        """
+        step = [0]
+        test_name = 'authorize_lang_spanish_button'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        if USE_NEW_PERM_SCREEN == 'true':
+            # the validation of expire date etc. only applicable to new perm screen
+            self._play(SPANISH_TESTS[test_name], step, api_ver=api_ver)
+        else:
+            print('Skip test ' + test_name + ' - only for new perm screen.')
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)

--- a/apps/integration_tests/selenium_tests.py
+++ b/apps/integration_tests/selenium_tests.py
@@ -1,5 +1,5 @@
 from apps.integration_tests.common_utils import screenshot_on_exception
-from apps.integration_tests.constants import TESTS
+from apps.integration_tests.constants import TESTS, USE_NEW_PERM_SCREEN
 from apps.integration_tests.selenium_generic import SeleniumGenericTests
 from apps.versions import Versions
 
@@ -12,135 +12,136 @@ class TestBlueButtonAPI(SeleniumGenericTests):
         SeleniumGenericTests (class): base selenium test class, runs via pytest
     """
 
-    # @screenshot_on_exception
-    # def test_auth_grant_fhir_calls_v2(self):
-    #     """
-    #     Test authorizing through the test client, using v2 URLs, and ensuring all of the
-    #     FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-    #     """
-    #     step = [0]
-    #     test_name = 'auth_grant_fhir_calls_v2'
-    #     api_ver = Versions.V2
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_auth_grant_fhir_calls_v2(self):
+        """
+        Test authorizing through the test client, using v2 URLs, and ensuring all of the
+        FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+        """
+        step = [0]
+        test_name = 'auth_grant_fhir_calls_v2'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_auth_grant_fhir_calls_v3(self):
-    #     """
-    #     Test authorizing through the test client, using v3 URLs, and ensuring all of the
-    #     FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-    #     """
-    #     step = [0]
-    #     test_name = 'auth_grant_fhir_calls_v3'
-    #     api_ver = Versions.V3
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_auth_grant_fhir_calls_v3(self):
+        """
+        Test authorizing through the test client, using v3 URLs, and ensuring all of the
+        FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+        """
+        step = [0]
+        test_name = 'auth_grant_fhir_calls_v3'
+        api_ver = Versions.V3
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_auth_deny_fhir_calls_v2(self):
-    #     """
-    #     Test denying authorization through the test client, using v2 URLs, and ensuring all of the
-    #     FHIR resources are NOT returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-    #     """
-    #     step = [0]
-    #     test_name = 'auth_deny_fhir_calls_v2'
-    #     api_ver = Versions.V2
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_auth_deny_fhir_calls_v2(self):
+        """
+        Test denying authorization through the test client, using v2 URLs, and ensuring all of the
+        FHIR resources are NOT returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+        """
+        step = [0]
+        test_name = 'auth_deny_fhir_calls_v2'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_auth_grant_w_no_demo_v2(self):
-    #     """
-    #     Test authorizing through the test client, using v2 URLs, and ensuring all of the
-    #     FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-    #     when the user has NOT chosen to share their demographic data in the system
-    #     """
-    #     step = [0]
-    #     if USE_NEW_PERM_SCREEN == 'true':
-    #         test_name = 'auth_grant_w_no_demo_new_perm_screen'
-    #     else:
-    #         test_name = 'auth_grant_w_no_demo_v2'
-    #     api_ver = Versions.V2
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_auth_grant_w_no_demo_v2(self):
+        """
+        Test authorizing through the test client, using v2 URLs, and ensuring all of the
+        FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+        when the user has NOT chosen to share their demographic data in the system
+        """
+        step = [0]
+        if USE_NEW_PERM_SCREEN == 'true':
+            test_name = 'auth_grant_w_no_demo_new_perm_screen'
+        else:
+            test_name = 'auth_grant_w_no_demo_v2'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_authorize_lang_english_button(self):
-    #     """
-    #     Test lang param support on the authorize end point via the built in
-    #     testclient using the Selenium web driver (Chrome)
-    #     direct to login url with lang=en by click on "Authorize as beneficiary" button
-    #     """
-    #     step = [0]
-    #     test_name = 'authorize_lang_english_button'
-    #     api_ver = Versions.V2
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     if USE_NEW_PERM_SCREEN == 'true':
-    #         # the validation of expire date etc. only applicable to new perm screen
-    #         self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     else:
-    #         print('Skip test ' + test_name + ' - only for new perm screen.')
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_authorize_lang_english_button(self):
+        """
+        Test lang param support on the authorize end point via the built in
+        testclient using the Selenium web driver (Chrome)
+        direct to login url with lang=en by click on "Authorize as beneficiary" button
+        """
+        step = [0]
+        test_name = 'authorize_lang_english_button'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        if USE_NEW_PERM_SCREEN == 'true':
+            # the validation of expire date etc. only applicable to new perm screen
+            self._play(TESTS[test_name], step, api_ver=api_ver)
+        else:
+            print('Skip test ' + test_name + ' - only for new perm screen.')
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_v2_authorization_and_scopes(self):
-    #     """
-    #     Test authorizing through the test client, using v2 URLs, and ensuring all of the
-    #     SMART App v2 Scopes are available within the returned token
-    #     """
-    #     step = [0]
-    #     test_name = 'authorize_get_v2_scopes'
-    #     api_ver = Versions.V2
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    @screenshot_on_exception
+    def test_v2_authorization_and_scopes(self):
+        """
+        Test authorizing through the test client, using v2 URLs, and ensuring all of the
+        SMART App v2 Scopes are available within the returned token
+        """
+        step = [0]
+        test_name = 'authorize_get_v2_scopes'
+        api_ver = Versions.V2
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
 
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
 
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_samhsa_box_checked_eob_response_v3(self):
-    #     """
-    #     Test that the samhsa checkbox is checked and that
-    #     _security%3Anot=42CFRPart2 is NOT part of the EOB
-    #     url response since we aren't filtering out any SAMHSA data.
-    #     """
-    #     step = [0]
-    #     test_name = 'samhsa_box_checked_eob_response_v3'
-    #     api_ver = Versions.V3
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_samhsa_box_checked_eob_response_v3(self):
+        """
+        Test that the samhsa checkbox is checked and that
+        _security%3Anot=42CFRPart2 is NOT part of the EOB
+        url response since we aren't filtering out any SAMHSA data.
+        """
+        step = [0]
+        test_name = 'samhsa_box_checked_eob_response_v3'
+        api_ver = Versions.V3
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
-    # @screenshot_on_exception
-    # def test_samhsa_box_not_checked_eob_response_v3(self):
-    #     """
-    #     Test that the samhsa checkbox is NOT checked and that
-    #     _security%3Anot=42CFRPart2 IS part of the EOB url response
-    #     since we are filtering out SAMHSA data.
-    #     """
-    #     step = [0]
-    #     test_name = 'samhsa_box_not_checked_eob_response_v3'
-    #     api_ver = Versions.V3
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-    #     self._play(TESTS[test_name], step, api_ver=api_ver)
-    #     self._testclient_home()
-    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    @screenshot_on_exception
+    def test_samhsa_box_not_checked_eob_response_v3(self):
+        """
+        Test that the samhsa checkbox is NOT checked and that
+        _security%3Anot=42CFRPart2 IS part of the EOB url response
+        since we are filtering out SAMHSA data.
+        """
+        step = [0]
+        test_name = 'samhsa_box_not_checked_eob_response_v3'
+        api_ver = Versions.V3
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+        self._play(TESTS[test_name], step, api_ver=api_ver)
+        self._testclient_home()
+        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
     @screenshot_on_exception
     def test_switch_account_v3(self):
         """
         Test switching accounts through the login flow, using v3 URLs, and ensuring
-        the new account can reach the test client home page
+        the new account can reach the test client home page. Login with BBUser09003,
+        then switch to BBUser00000 and ensure the test client home page is reached.
         """
         step = [0]
         test_name = 'switch_account_v3'

--- a/apps/integration_tests/selenium_tests.py
+++ b/apps/integration_tests/selenium_tests.py
@@ -1,5 +1,5 @@
 from apps.integration_tests.common_utils import screenshot_on_exception
-from apps.integration_tests.constants import TESTS, USE_NEW_PERM_SCREEN
+from apps.integration_tests.constants import TESTS
 from apps.integration_tests.selenium_generic import SeleniumGenericTests
 from apps.versions import Versions
 
@@ -12,124 +12,138 @@ class TestBlueButtonAPI(SeleniumGenericTests):
         SeleniumGenericTests (class): base selenium test class, runs via pytest
     """
 
-    @screenshot_on_exception
-    def test_auth_grant_fhir_calls_v2(self):
-        """
-        Test authorizing through the test client, using v2 URLs, and ensuring all of the
-        FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-        """
-        step = [0]
-        test_name = 'auth_grant_fhir_calls_v2'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        self._play(TESTS[test_name], step, api_ver=api_ver)
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+    # @screenshot_on_exception
+    # def test_auth_grant_fhir_calls_v2(self):
+    #     """
+    #     Test authorizing through the test client, using v2 URLs, and ensuring all of the
+    #     FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+    #     """
+    #     step = [0]
+    #     test_name = 'auth_grant_fhir_calls_v2'
+    #     api_ver = Versions.V2
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_auth_grant_fhir_calls_v3(self):
+    #     """
+    #     Test authorizing through the test client, using v3 URLs, and ensuring all of the
+    #     FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+    #     """
+    #     step = [0]
+    #     test_name = 'auth_grant_fhir_calls_v3'
+    #     api_ver = Versions.V3
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_auth_deny_fhir_calls_v2(self):
+    #     """
+    #     Test denying authorization through the test client, using v2 URLs, and ensuring all of the
+    #     FHIR resources are NOT returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+    #     """
+    #     step = [0]
+    #     test_name = 'auth_deny_fhir_calls_v2'
+    #     api_ver = Versions.V2
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_auth_grant_w_no_demo_v2(self):
+    #     """
+    #     Test authorizing through the test client, using v2 URLs, and ensuring all of the
+    #     FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+    #     when the user has NOT chosen to share their demographic data in the system
+    #     """
+    #     step = [0]
+    #     if USE_NEW_PERM_SCREEN == 'true':
+    #         test_name = 'auth_grant_w_no_demo_new_perm_screen'
+    #     else:
+    #         test_name = 'auth_grant_w_no_demo_v2'
+    #     api_ver = Versions.V2
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_authorize_lang_english_button(self):
+    #     """
+    #     Test lang param support on the authorize end point via the built in
+    #     testclient using the Selenium web driver (Chrome)
+    #     direct to login url with lang=en by click on "Authorize as beneficiary" button
+    #     """
+    #     step = [0]
+    #     test_name = 'authorize_lang_english_button'
+    #     api_ver = Versions.V2
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     if USE_NEW_PERM_SCREEN == 'true':
+    #         # the validation of expire date etc. only applicable to new perm screen
+    #         self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     else:
+    #         print('Skip test ' + test_name + ' - only for new perm screen.')
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_v2_authorization_and_scopes(self):
+    #     """
+    #     Test authorizing through the test client, using v2 URLs, and ensuring all of the
+    #     SMART App v2 Scopes are available within the returned token
+    #     """
+    #     step = [0]
+    #     test_name = 'authorize_get_v2_scopes'
+    #     api_ver = Versions.V2
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_samhsa_box_checked_eob_response_v3(self):
+    #     """
+    #     Test that the samhsa checkbox is checked and that
+    #     _security%3Anot=42CFRPart2 is NOT part of the EOB
+    #     url response since we aren't filtering out any SAMHSA data.
+    #     """
+    #     step = [0]
+    #     test_name = 'samhsa_box_checked_eob_response_v3'
+    #     api_ver = Versions.V3
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
+
+    # @screenshot_on_exception
+    # def test_samhsa_box_not_checked_eob_response_v3(self):
+    #     """
+    #     Test that the samhsa checkbox is NOT checked and that
+    #     _security%3Anot=42CFRPart2 IS part of the EOB url response
+    #     since we are filtering out SAMHSA data.
+    #     """
+    #     step = [0]
+    #     test_name = 'samhsa_box_not_checked_eob_response_v3'
+    #     api_ver = Versions.V3
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
+    #     self._play(TESTS[test_name], step, api_ver=api_ver)
+    #     self._testclient_home()
+    #     self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
 
     @screenshot_on_exception
-    def test_auth_grant_fhir_calls_v3(self):
+    def test_switch_account_v3(self):
         """
-        Test authorizing through the test client, using v3 URLs, and ensuring all of the
-        FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-        """
-        step = [0]
-        test_name = 'auth_grant_fhir_calls_v3'
-        api_ver = Versions.V3
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        self._play(TESTS[test_name], step, api_ver=api_ver)
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
-
-    @screenshot_on_exception
-    def test_auth_deny_fhir_calls_v2(self):
-        """
-        Test denying authorization through the test client, using v2 URLs, and ensuring all of the
-        FHIR resources are NOT returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
+        Test switching accounts through the login flow, using v3 URLs, and ensuring
+        the new account can reach the test client home page
         """
         step = [0]
-        test_name = 'auth_deny_fhir_calls_v2'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        self._play(TESTS[test_name], step, api_ver=api_ver)
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
-
-    @screenshot_on_exception
-    def test_auth_grant_w_no_demo_v2(self):
-        """
-        Test authorizing through the test client, using v2 URLs, and ensuring all of the
-        FHIR resources are returned (ie. the EOB, Patient, Coverage, and ExplanationOfBenefit resources)
-        when the user has NOT chosen to share their demographic data in the system
-        """
-        step = [0]
-        if USE_NEW_PERM_SCREEN == 'true':
-            test_name = 'auth_grant_w_no_demo_new_perm_screen'
-        else:
-            test_name = 'auth_grant_w_no_demo_v2'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        self._play(TESTS[test_name], step, api_ver=api_ver)
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
-
-    @screenshot_on_exception
-    def test_authorize_lang_english_button(self):
-        """
-        Test lang param support on the authorize end point via the built in
-        testclient using the Selenium web driver (Chrome)
-        direct to login url with lang=en by click on "Authorize as beneficiary" button
-        """
-        step = [0]
-        test_name = 'authorize_lang_english_button'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        if USE_NEW_PERM_SCREEN == 'true':
-            # the validation of expire date etc. only applicable to new perm screen
-            self._play(TESTS[test_name], step, api_ver=api_ver)
-        else:
-            print('Skip test ' + test_name + ' - only for new perm screen.')
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
-
-    @screenshot_on_exception
-    def test_v2_authorization_and_scopes(self):
-        """
-        Test authorizing through the test client, using v2 URLs, and ensuring all of the
-        SMART App v2 Scopes are available within the returned token
-        """
-        step = [0]
-        test_name = 'authorize_get_v2_scopes'
-        api_ver = Versions.V2
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-
-        self._play(TESTS[test_name], step, api_ver=api_ver)
-
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
-
-    @screenshot_on_exception
-    def test_samhsa_box_checked_eob_response_v3(self):
-        """
-        Test that the samhsa checkbox is checked and that
-        _security%3Anot=42CFRPart2 is NOT part of the EOB
-        url response since we aren't filtering out any SAMHSA data.
-        """
-        step = [0]
-        test_name = 'samhsa_box_checked_eob_response_v3'
-        api_ver = Versions.V3
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
-        self._play(TESTS[test_name], step, api_ver=api_ver)
-        self._testclient_home()
-        self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, False)
-
-    @screenshot_on_exception
-    def test_samhsa_box_not_checked_eob_response_v3(self):
-        """
-        Test that the samhsa checkbox is NOT checked and that
-        _security%3Anot=42CFRPart2 IS part of the EOB url response
-        since we are filtering out SAMHSA data.
-        """
-        step = [0]
-        test_name = 'samhsa_box_not_checked_eob_response_v3'
+        test_name = 'switch_account_v3'
         api_ver = Versions.V3
         self._print_testcase_banner(test_name, api_ver, step[0], self.use_mslsx, True)
         self._play(TESTS[test_name], step, api_ver=api_ver)


### PR DESCRIPTION
<!--
You've got a Pull Request you want to submit? Awesome!
This PR template is here to help ensure you're setup for success:
  please fill it out to help ensure that your PR is complete and ready for approval.
-->

**JIRA Ticket:**
[BB2-4994](https://jira.cms.gov/browse/BB2-4994)

### What Does This PR Do?
This PR adds a selenium test that goes to the v3 permissions screen with BBUser09003, clicks Switch account, and then logs in as a different user BBUser_00000. The test should confirm that the second user, who clicks Share on the v3 permissions screen, successfully accesses the testclient page.

Summary of Changes:
- Added a selenium test testing the switch account functionality above to selenium_tests.py
- Unrelated to the actual story I added doc strings to each of the selenium_generic.py tests to make it easier to understand what's going on
- Did some rework on the login functionality to make it easier to login with new users. Before it was hardcoding the login flows for only one specific user so I made it more dynamic by being able to pass in params for the login info of any user, regardless if it's the MSLSX or SLSX flow.
- Renamed CALL_LOGIN to be CALL_LOGIN_BBUSER_09003 to be explicit about who's logging in in all the test cases. Added CALL_LOGIN_BBUSER_00000 to be the second user login

<!--
Add detailed description & discussion of changes here.
-->

### What Should Reviewers Watch For?

<!--
Common items include:
* Is this likely to address the goals expressed in the user story?
* Are any additional documentation updates needed?
* Are there any unhandled and/or untested edge cases you can think of?
* Is user input properly sanitized & handled?
* Does this make any backwards-incompatible changes that might break end user clients?
* Can you find any bugs if you run the code locally and test it manually?
-->

If you're reviewing this PR, please check for these things in particular:
<!-- Add some items here -->

### Validation
- See that all selenium tests pass in the PR checks, including the newest added one as a part of this [PR](https://github.com/CMSgov/bluebutton-web-server/actions/runs/33920412542/job/101179797232?pr=1725). There should be 12 total now.
- I don't think you will be able to because of ZScaler but you can check out this branch and try to debug the selenium test with slsx (not mslsx) by following the instructions in the `Debugging` section of ops/containers/selenium/README.md. However, instead of bringing up the bb-api stack with auth=mock, you can bring it up with auth=live (just run `make run-local`). For selenium you can then run `make run-selenium-local debug=true`. You can comment out other selenium tests to make it easier to debug and set breakpoints accordingly. But you should at least be able to get past the first log in with BBUser09003 and then you'll likely get the ZScaler issue. I can huddle if it's too hard to do this on your own but running against prod/sbx below seems like the most promising way of testing it with slsx.
- You can run `./docker-compose/run_selenium_tests_remote.sh PROD` or SBX and all 12 should pass
<!--
Have you fully verified and tested these changes? Is the acceptance criteria met? Please provide reproducible testing instructions, code snippets, or screenshots as applicable.
-->

### What Security Implications Does This PR Have?

Please indicate if this PR does any of the following:

* Adds any new software dependencies
* Modifies any security controls
* Adds new transmission or storage of data
* Any other changes that could possibly affect security?

- [ ] Yes, one or more of the above security implications apply. This PR must not be merged without the ISSO or team
  security engineer's approval.

### Any Migrations?

<!--
Make sure to work with whoever is doing the deploy so they are aware of any migrations that may need to be run
-->

* [ ] Yes, there are migrations
    * [ ] The migrations should be run PRIOR to the code being deployed
    * [ ] The migrations should be run AFTER the code is deployed
    * [ ] There is a more complicated migration plan (downtime,
      etc) <!-- Make sure to include the details of the plan below -->
* [x] No migrations
